### PR TITLE
EOF tokenizer was causing duplicate text contents

### DIFF
--- a/lib/vendor/simple-html-tokenizer.js
+++ b/lib/vendor/simple-html-tokenizer.js
@@ -52,8 +52,10 @@ Tokenizer.prototype = {
   },
 
   tokenizeEOF: function() {
-    if (this.token) {
-      return this.token;
+    var token = this.token;
+    if (token) {
+      this.token = null;
+      return token;
     }
   },
 
@@ -427,7 +429,7 @@ function CommentToken() {
 CommentToken.prototype = {
   type: 'CommentToken',
   constructor: CommentToken,
-  
+
   finalize: function() { return this; },
 
   addChar: function(char) {

--- a/tests/html_compiler_tests.js
+++ b/tests/html_compiler_tests.js
@@ -450,6 +450,14 @@ test("A simple block helper can return the default document fragment", function(
   compilesTo('{{#testing}}<div id="test">123</div>{{/testing}}', '<div id="test">123</div>');
 });
 
+test("A simple block helper can return text nodes accurately", function() {
+  registerHelper('testing', function(options) {
+    return options.render(this);
+  });
+
+  compilesTo('{{#testing}}test{{/testing}}', 'test');
+});
+
 test("A block helper can pass a context to be used in the child", function() {
   registerHelper('testing', function(options) {
     return options.render({ title: 'Rails is omakase' });
@@ -528,7 +536,7 @@ test("Data-bound block helpers", function() {
   object.shouldRender = true;
   callback();
 
-  equalHTML(fragment, '<p>hi</p> content <p>Appears!</p> more <em>content</em> here'); 
+  equalHTML(fragment, '<p>hi</p> content <p>Appears!</p> more <em>content</em> here');
 
   object.shouldRender = false;
   callback();


### PR DESCRIPTION
I just discovered this recently and was writing a small library built on top of it, but I have found a few issues. I plan to work through them, but this one was an immediate blocker. Basically whenever a block ends with a text node the node was being appended to both the block and the parents block. Adds a corresponding test case.

Unrelated question: What is the compatibility with Handlebars intending to be like? I have found that there are no `{{else}}` blocks, no passing in custom data for the `@` variable references, no passing custom helpers to each template, `options.fn` is now called `options.render`, etc. I would love to contribute to this if these are issues that should be solved.
