### PR TITLE
Rerender of attributes have different options

### DIFF
--- a/lib/htmlbars/compiler/pass2.js
+++ b/lib/htmlbars/compiler/pass2.js
@@ -97,12 +97,10 @@ compiler2.openElement = function(tagName) {
 };
 
 compiler2.attribute = function(name, child) {
-  var invokeRererender = call('el.setAttribute', string(name), call('child' + child, 'context', hash(['rerender:rerender'])));
-  var rerender = 'function rerender() { ' + invokeRererender + '}';
-  var options = hash(['rerender:' + rerender, 'element:el', 'attrName:' + string(name)]);
-  pushStack(this.stack, call('child' + child, 'context', options));
+  var options = hash(['rerender:rerender', 'element:el', 'attrName:' + string(name)]);
+  var invokeRererender = call('el.setAttribute', string(name), call('child' + child, 'context', options));
 
-  this.push(call('el.setAttribute', string(name), popStack(this.stack)));
+  this.push(call('(function rerender() { ' + invokeRererender + '})'));
 };
 
 compiler2.closeElement = function() {

--- a/tests/html_compiler_tests.js
+++ b/tests/html_compiler_tests.js
@@ -391,6 +391,10 @@ test("It is possible to trigger a re-render of an attribute from a child resolut
       options.rerender();
     }
 
+    ok(typeof options.rerender === 'function');
+    equal(options.attrName, 'href');
+    equal(options.element.tagName, 'A');
+
     return this[path];
   });
 
@@ -528,7 +532,7 @@ test("Data-bound block helpers", function() {
   object.shouldRender = true;
   callback();
 
-  equalHTML(fragment, '<p>hi</p> content <p>Appears!</p> more <em>content</em> here'); 
+  equalHTML(fragment, '<p>hi</p> content <p>Appears!</p> more <em>content</em> here');
 
   object.shouldRender = false;
   callback();


### PR DESCRIPTION
Rerender function was calling resolve with a different set of options to the first time around (missing `element` and `attrName`). Added a couple of simple checks to an existing test to make sure it functions as expected.
