### PR TITLE
Implement stripping

### DIFF
--- a/lib/htmlbars/ast.js
+++ b/lib/htmlbars/ast.js
@@ -1,12 +1,24 @@
 import AST from "handlebars/compiler/ast";
 
-export var ProgramNode = AST.ProgramNode;
-export var BlockNode = AST.BlockNode;
 export var MustacheNode = AST.MustacheNode;
 export var SexprNode = AST.SexprNode;
 export var HashNode = AST.HashNode;
 export var IdNode = AST.IdNode;
 export var StringNode = AST.StringNode;
+
+export function ProgramNode(statements, strip) {
+  this.type = 'program';
+  this.statements = statements;
+  this.strip = strip;
+}
+
+export function BlockNode(mustache, program, inverse, strip) {
+  this.type = 'block';
+  this.mustache = mustache;
+  this.program = program;
+  this.inverse = inverse;
+  this.strip = strip;
+}
 
 export function ElementNode(tag, attributes, helpers, children) {
   this.type = 'element';

--- a/lib/htmlbars/parser.js
+++ b/lib/htmlbars/parser.js
@@ -22,29 +22,56 @@ processor.accept = function(node) {
 };
 
 processor.program = function(program) {
-  var children = [];
-  var node = new ProgramNode(children, program.strip);
-  var statements = program.statements;
-  var c, l = statements.length;
+  var statements = [];
+  var node = new ProgramNode(statements, program.strip);
+  var i, l = program.statements.length;
+  var statement;
 
   this.elementStack.push(node);
 
   if (l === 0) return this.elementStack.pop();
 
-  c = statements[0];
-  if (c.type === 'block' || c.type === 'mustache') {
-    children.push(new TextNode(''));
+  statement = program.statements[0];
+  if (statement.type === 'block' || statement.type === 'mustache') {
+    statements.push(new TextNode(''));
   }
 
-  for (var i = 0; i < l; i++) {
-    this.accept(statements[i]);
+  for (i = 0; i < l; i++) {
+    this.accept(program.statements[i]);
   }
 
   process(this, this.tokenizer.tokenizeEOF());
 
-  c = statements[l-1];
-  if (c.type === 'block' || c.type === 'mustache') {
-    children.push(new TextNode(''));
+  statement = program.statements[l-1];
+  if (statement.type === 'block' || statement.type === 'mustache') {
+    statements.push(new TextNode(''));
+  }
+
+  // Remove any stripped whitespace
+  l = statements.length;
+  for (i = 0; i < l; i++) {
+    statement = statements[i];
+    if (statement.type !== 'text') continue;
+
+    if ((i > 0 && statements[i-1].strip && statements[i-1].strip.right) ||
+      (i === 0 && program.strip.left)) {
+      statement.chars = statement.chars.replace(/^\s+/, '');
+    }
+
+    if ((i < l-1 && statements[i+1].strip && statements[i+1].strip.left) ||
+      (i === l-1 && program.strip.right)) {
+      statement.chars = statement.chars.replace(/\s+$/, '');
+    }
+
+    // Remove unnecessary text nodes
+    if (statement.chars.length === 0) {
+      if ((i > 0 && statements[i-1].type === 'element') ||
+        (i < l-1 && statements[i+1].type === 'element')) {
+        statements.splice(i, 1);
+        i--;
+        l--;
+      }
+    }
   }
 
   return this.elementStack.pop();
@@ -58,11 +85,14 @@ processor.block = function(block) {
   var mustache = block.mustache;
   var program = this.accept(block.program);
   var inverse = block.inverse ? this.accept(block.inverse) : null;
+  var strip = block.strip;
 
-  // TODO: Clean up Handlebars AST upstream to remove this hack.
-  var close = buildClose(mustache, program, inverse, block.strip.right);
+  // Normalize inverse's strip
+  if (inverse && !inverse.strip.left) {
+    inverse.strip.left = false;
+  }
 
-  var node = new BlockNode(mustache, program, inverse, close);
+  var node = new BlockNode(mustache, program, inverse, strip);
   var parentProgram = currentElement(this);
   appendChild(parentProgram, node);
 };
@@ -142,15 +172,3 @@ StartTag.prototype.addTagHelper = function(helper) {
   var helpers = this.helpers = this.helpers || [];
   helpers.push(helper);
 };
-
-export function buildClose(mustache, program, inverse, stripRight) {
-  return {
-    path: {
-      original: mustache.sexpr.id.original
-    },
-    strip: {
-      left: (inverse || program).strip.right,
-      right: stripRight || false
-    },
-  };
-}


### PR DESCRIPTION
The parser now respects the handlebars whitespace control flags. Whitespace is removed from the AST at parse time. Any unnecessary text nodes are removed. This works nicely with single element programs. Instead of writing

``` handlebars
{{#each}}<li>foo</li>{{/each}}
```

you can write

``` handlebars
{{#each~}}
  <li>foo</li>
{{~/each}}
```

and still generate an optimized fragment

``` javascript
function build(dom) {
  var el0 = dom.createElement('li');
  dom.appendText(el0, 'foo');
  return el0;
}
```
