### PR TITLE
Attribute value refactor

### DIFF
--- a/lib/htmlbars/compiler/fragment_opcode.js
+++ b/lib/htmlbars/compiler/fragment_opcode.js
@@ -57,10 +57,9 @@ FragmentOpcodeCompiler.prototype.node = function () {};
 
 FragmentOpcodeCompiler.prototype.block = function () {};
 
-FragmentOpcodeCompiler.prototype.attribute = function(attribute) {
-  var name = attribute.name, value = attribute.value;
-  if (value.length === 1 && value[0].type === 'text') {
-    this.opcode('setAttribute', [name, value[0].chars]);
+FragmentOpcodeCompiler.prototype.attribute = function(attr) {
+  if (attr.value.type === 'text') {
+    this.opcode('setAttribute', [attr.name, attr.value.chars]);
   }
 };
 

--- a/lib/htmlbars/compiler/hydration_opcode.js
+++ b/lib/htmlbars/compiler/hydration_opcode.js
@@ -89,30 +89,14 @@ HydrationOpcodeCompiler.prototype.opcode = function(type) {
   this.opcodes.push([type, params]);
 };
 
-HydrationOpcodeCompiler.prototype.attribute = function(attribute) {
-  var name = attribute.name, value = attribute.value;
-
-  if (value.length === 0 || (value.length === 1 && value[0].type === 'text')) {
-    return;
-  }
+HydrationOpcodeCompiler.prototype.attribute = function(attr) {
+  if (attr.value.type === 'text') return;
 
   // We treat attribute like a ATTRIBUTE helper evaluated by the ELEMENT hook.
   // <p {{ATTRIBUTE 'class' 'foo ' (bar)}}></p>
-
   // Unwrapped any mustaches to just be their internal sexprs.
-  var params = [name];
-
-  for (var i = 0, l = value.length; i < l; i++) {
-    var node = value[i];
-    if (node.type === 'mustache') {
-      params.push(node.sexpr);
-    } else {
-      params.push(node);
-    }
-  }
-
   this.nodeHelper({
-    params: params,
+    params: [attr.name, attr.value.sexpr],
     hash: null,
     id: {
       string: 'ATTRIBUTE'

--- a/lib/htmlbars/html-parser/tokens.js
+++ b/lib/htmlbars/html-parser/tokens.js
@@ -1,8 +1,8 @@
 import { Chars, StartTag, EndTag } from "simple-html-tokenizer";
-import { AttrNode, TextNode } from "htmlbars/ast";
+import { AttrNode, TextNode, MustacheNode, StringNode, IdNode } from "htmlbars/ast";
 
 StartTag.prototype.startAttribute = function(char) {
-  this.addCurrentAttributeKey();
+  this.finalizeAttributeValue();
   this.currentAttribute = new AttrNode(char.toLowerCase(), []);
   this.attributes.push(this.currentAttribute);
 };
@@ -26,15 +26,39 @@ StartTag.prototype.addToAttributeValue = function(char) {
 };
 
 StartTag.prototype.finalize = function() {
-  this.addCurrentAttributeKey();
+  this.finalizeAttributeValue();
   delete this.currentAttribute;
   return this;
 };
 
-StartTag.prototype.addCurrentAttributeKey = function() {
+StartTag.prototype.finalizeAttributeValue = function() {
   var attr = this.currentAttribute;
-  if (attr) {
-    this.attributes[attr.name] = attr.value;
+
+  if (!attr) return;
+
+  if (attr.value.length === 1) {
+    // Unwrap a single TextNode or MustacheNode
+    attr.value = attr.value[0];
+  } else {
+    var params = [ new IdNode([{ part: 'CONCAT' }]) ];
+
+    for (var i = 0; i < attr.value.length; i++) {
+      var part = attr.value[i];
+      if (part.type === 'text') {
+        params.push(new StringNode(part.chars));
+      } else if (part.type === 'mustache') {
+        var sexpr = part.sexpr;
+        delete sexpr.isRoot;
+
+        if (sexpr.isHelper) {
+          sexpr.isHelper = true;
+        }
+
+        params.push(sexpr);
+      }
+    }
+
+    attr.value = new MustacheNode(params, undefined, true, { left: false, right: false });
   }
 };
 

--- a/lib/htmlbars/runtime/helpers.js
+++ b/lib/htmlbars/runtime/helpers.js
@@ -22,13 +22,19 @@ export function ELEMENT(element, helperName, context, params, options) {
 }
 
 export function ATTRIBUTE(context, params, options) {
-  for (var i = 1, l = params.length; i < l; ++i) {
+  options.element.setAttribute(params[0], params[1]);
+}
+
+export function CONCAT(context, params, options) {
+  var value = "";
+  for (var i = 0, l = params.length; i < l; i++) {
     if (options.types[i] === 'id') {
-      params[i] = this.SIMPLE(context, params[i], options);
+      value += this.SIMPLE(context, params[i], options);
+    } else {
+      value += params[i];
     }
   }
-
-  options.element.setAttribute(params[0], params.slice(1).join(''));
+  return value;
 }
 
 export function SUBEXPR(helperName, context, params, options) {
@@ -43,10 +49,11 @@ export function SUBEXPR(helperName, context, params, options) {
 export function LOOKUP_HELPER(helperName, context, options) {
   if (helperName === 'ATTRIBUTE') {
     return this.ATTRIBUTE;
+  } else if (helperName === 'CONCAT') {
+    return this.CONCAT;
   }
 }
 
 export function SIMPLE(context, name, options) {
   return context[name];
 }
-

--- a/test/tests/html_compiler_test.js
+++ b/test/tests/html_compiler_test.js
@@ -1,6 +1,6 @@
 import { compile } from "htmlbars/compiler";
 import { tokenize } from "simple-html-tokenizer";
-import { CONTENT, ELEMENT, ATTRIBUTE, SUBEXPR, LOOKUP_HELPER, SIMPLE } from "htmlbars/runtime/helpers";
+import { CONTENT, ELEMENT, ATTRIBUTE, CONCAT, SUBEXPR, SIMPLE } from "htmlbars/runtime/helpers";
 
 function frag(element, string) {
   if (element instanceof DocumentFragment) {
@@ -22,6 +22,8 @@ function registerHelper(name, callback) {
 function lookupHelper(helperName, context, options) {
   if (helperName === 'ATTRIBUTE') {
     return this.ATTRIBUTE;
+  } else if (helperName === 'CONCAT') {
+    return this.CONCAT;
   } else {
     return helpers[helperName];
   }
@@ -30,7 +32,7 @@ function lookupHelper(helperName, context, options) {
 module("HTML-based compiler (output)", {
   setup: function() {
     helpers = [];
-    hooks = { CONTENT: CONTENT, ELEMENT: ELEMENT, ATTRIBUTE: ATTRIBUTE, SUBEXPR: SUBEXPR, LOOKUP_HELPER: lookupHelper, SIMPLE: SIMPLE };
+    hooks = { CONTENT: CONTENT, ELEMENT: ELEMENT, ATTRIBUTE: ATTRIBUTE, CONCAT: CONCAT, SUBEXPR: SUBEXPR, LOOKUP_HELPER: lookupHelper, SIMPLE: SIMPLE };
   }
 });
 

--- a/test/tests/hydration_compiler_test.js
+++ b/test/tests/hydration_compiler_test.js
@@ -128,6 +128,8 @@ test("attribute mustache", function() {
   deepEqual(opcodes, [
     [ "program", [null, null] ],
     [ "stringLiteral", ["class"] ],
+    [ "string", ["sexpr"] ],
+    [ "program", [null, null] ],
     [ "stringLiteral", ["before "] ],
     [ "string", ["sexpr"] ],
     [ "program", [null, null] ],
@@ -135,7 +137,9 @@ test("attribute mustache", function() {
     [ "sexpr", [ "foo", 0 ] ],
     [ "stringLiteral", [" after"] ],
     [ "stackLiteral", [0] ],
-    [ "nodeHelper", [ "ATTRIBUTE", 4, [ 0 ] ] ]
+    [ "sexpr", [ "CONCAT", 3 ] ],
+    [ "stackLiteral", [0] ],
+    [ "nodeHelper", [ "ATTRIBUTE", 2, [ 0 ] ] ]
   ]);
 });
 
@@ -145,6 +149,8 @@ test("attribute helper", function() {
   deepEqual(opcodes, [
     [ "program", [ null, null ] ],
     [ "stringLiteral", [ "class" ] ],
+    [ "string", [ "sexpr" ] ],
+    [ "program", [ null, null ] ],
     [ "stringLiteral", [ "before " ] ],
     [ "string", [ "sexpr" ] ],
     [ "program", [ null, null ] ],
@@ -153,6 +159,8 @@ test("attribute helper", function() {
     [ "sexpr", [ "foo", 1 ] ],
     [ "stringLiteral", [ " after" ] ],
     [ "stackLiteral", [ 0 ] ],
-    [ "nodeHelper", [ "ATTRIBUTE", 4, [ 0 ] ] ]
+    [ "sexpr", [ "CONCAT", 3 ] ],
+    [ "stackLiteral", [ 0 ] ],
+    [ "nodeHelper", [ "ATTRIBUTE", 2, [ 0 ] ] ]
   ]);
 });


### PR DESCRIPTION
Attribute values are no longer represented as arrays in the AST. Instead an attribute value is either a TextNode or MustacheNode. If the attribute contains both text and mustache parts, they are concatenated via the CONCAT helper. Examples:
- class="btn-large" parses as `text("btn-large")`
- class="{{status}}" parses as `mustache("status")`
- class="btn-large {{status}}" parses as `mustache("CONCAT", params: [string("btn-large "), id("status")])`

Consequently, the ATTRIBUTE hook no longer accepts arrays and instead expects a value.
