### PR TITLE
Fix text-only attributes in components and empty components

### DIFF
--- a/lib/htmlbars/html-parser/helpers.js
+++ b/lib/htmlbars/html-parser/helpers.js
@@ -1,7 +1,8 @@
-import { TextNode, HashNode, usesPlaceholder } from "htmlbars/ast";
+import { TextNode, StringNode, HashNode, usesPlaceholder } from "htmlbars/ast";
 
-// Rewrites an array of AttrNodes into a HashNode, unwrapping
-// any mustaches to their root sexprs along the way.
+// Rewrites an array of AttrNodes into a HashNode.
+// MustacheNodes are replaced with their root SexprNode and
+// TextNodes are replaced with StringNodes
 
 export function buildHashFromAttributes(attributes) {
   var pairs = [];
@@ -10,8 +11,8 @@ export function buildHashFromAttributes(attributes) {
     var attr = attributes[i];
     if (attr.value.type === 'mustache') {
       pairs.push([attr.name, attr.value.sexpr]);
-    } else {
-      pairs.push([attr.name, attr.value]);
+    } else if (attr.value.type === 'text') {
+      pairs.push([attr.name, new StringNode(attr.value.chars)]);
     }
   }
 
@@ -24,6 +25,8 @@ export function buildHashFromAttributes(attributes) {
 
 export function postprocessProgram(program) {
   var statements = program.statements;
+
+  if (statements.length === 0) return;
 
   if (usesPlaceholder(statements[0])) {
     statements.unshift(new TextNode(''));

--- a/test/tests/html_compiler_test.js
+++ b/test/tests/html_compiler_test.js
@@ -714,3 +714,12 @@ test('Web components - Unknown helpers fall back to elements', function () {
   var object = { size: 'med', foo: 'b' };
   compilesTo('<x-bar class="btn-{{size}}">a{{foo}}c</x-bar>','<x-bar class="btn-med">abc</x-bar>', object);
 });
+
+test('Web components - Text-only attributes work', function () {
+  var object = { foo: 'qux' };
+  compilesTo('<x-bar id="test">{{foo}}</x-bar>','<x-bar id="test">qux</x-bar>', object);
+});
+
+test('Web components - Empty components work', function () {
+  compilesTo('<x-bar></x-bar>','<x-bar></x-bar>', {});
+});


### PR DESCRIPTION
Fixes

```
<x-foo id="foo1"></x-foo>
```

Broken version: http://jsbin.com/wonuz/6
Working version: http://jsbin.com/wonuz/7
