### PR TITLE
Broccolify project

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,235 +1,34 @@
 module.exports = function(grunt) {
-  // Alias tasks for the most common sets of tasks.
-  // Most of the time, you will use these.
+  grunt.loadNpmTasks('grunt-broccoli');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-qunit');
+  grunt.loadTasks('tasks');
 
-  // By default, (i.e., if you invoke `grunt` without arguments), do
-  // a new build.
-  this.registerTask('default', ['test']);
-
-  this.registerTask('dist', "Builds a distributable version of htmlbars",
-                    ['jshint',
-                     'build',
-                     'concat_sourcemap:library',
-                     'concat_sourcemap:browser',
-                     'fix_sourcemap:library',
-                     'fix_sourcemap:browser',
-                     'copy:sources',
-                     'uglify:library',
-                     'uglify:browser',
-                     'bytes'
-                    ]);
-
-  // Build a new version of the library
-  this.registerTask('build', "Builds a htmlbars",
-                    ['clean',
-                     'transpile:amd',
-                     'concat_sourcemap:amd',
-                     'fix_sourcemap:amd'
-                    ]);
-
-  this.registerTask('tests', "Builds the test package",
-                    ['build',
-                     'transpile:tests',
-                     'concat_sourcemap:tests',
-                     'fix_sourcemap:tests'
-                    ]);
-
-  // Run a server. This is ideal for running the QUnit tests in the browser.
-  this.registerTask('server', ['tests', 'connect', 'watch']);
-
-  this.registerTask('test', ['jshint', 'tests', 'qunit']);
-
+  grunt.registerTask('server', 'broccoli:browser:serve');
+  grunt.registerTask('dist', ['clean', 'broccoli:dist:build']);
+  grunt.registerTask('test', ['clean:tmp', 'broccoli:browser:build', 'qunit:all']);
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
-    connect: {
-      server: {},
-
-      options: {
-        hostname: '0.0.0.0',
-        port: grunt.option('port') || 8000,
-        base: '.',
-        middleware: function(connect, options) {
-          return [
-            require('connect-redirection')(),
-            function(req, res, next) {
-              if (req.url === '/') {
-                res.redirect('/test');
-              } else {
-                next();
-              }
-            },
-            connect.static(options.base)
-          ];
-        }
-      }
-    },
-
-    watch: {
-      files: ['lib/**', 'vendor/*', 'test/**/*'],
-      tasks: ['tests', 'jshint']
-    },
-
-    transpile: {
-      amd: {
-        type: "amd",
-        files: [{
-          expand: true,
-          cwd: 'lib/',
-          src: ['**/*.js'],
-          dest: 'tmp/'
-        }]
-      },
-
-      tests: {
-        type: 'amd',
-        files: [{
-          expand: true,
-          cwd: 'test/',
-          src: ['test_helpers.js', 'tests.js', 'tests/**/*_test.js'],
-          dest: 'tmp/'
-        }]
-      }
-    },
-
-    concat_sourcemap: {
-      amd: {
-        files: [{
-          src: ['tmp/htmlbars.js', 'tmp/htmlbars/**/*.js', 'tmp/vendor/*.js'],
-          dest: 'tmp/htmlbars.amd.js'
-        }]
-      },
-      tests: {
-        files: [{
-          src: ['tmp/tests/*.js'],
-          dest: 'tmp/tests.amd.js'
-        }]
-      },
-      library: {
-        src: ['tmp/<%= pkg.name %>.amd.js'],
-        dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.amd.js'
+    broccoli: {
+      dist: {
+        config: 'tasks/build/dist.js',
+        dest: 'dist'
       },
       browser: {
-        src: [
-          'wrap/browser.start',
-          'vendor/loader.js',
-          'vendor/handlebars.amd.js',
-          'vendor/simple-html-tokenizer.amd.js',
-          'tmp/<%= pkg.name %>.amd.js',
-          'wrap/browser.end'
-        ],
-        dest: 'dist/<%= pkg.name %>-<%= pkg.version %>.js'
+        config: 'tasks/build/browser.js',
+        dest: 'tmp/test'
       }
     },
 
-    fix_sourcemap: {
-      amd: {
-        files: {
-          src: 'tmp/htmlbars.amd.js.map'
-        }
-      },
-      tests: {
-        files: {
-          src: 'tmp/tests.amd.js.map'
-        }
-      },
-      library: {
-        root: 'sources-<%= pkg.version %>',
-        files: {
-          src: 'dist/<%= pkg.name %>-<%= pkg.version %>.amd.js.map'
-        }
-      },
-      browser: {
-        root: 'sources-<%= pkg.version %>',
-        files: {
-          src: 'dist/<%= pkg.name %>-<%= pkg.version %>.js.map'
-        }
-      }
+    clean: {
+      dist: 'dist',
+      tmp: 'tmp'
     },
-
-    copy: {
-      sources: {
-        files: [{
-          expand: true,
-          cwd: 'tmp/',
-          src: ['<%= pkg.name %>.js', '<%= pkg.name %>.amd.js', '<%= pkg.name %>.amd.js.map', '<%= pkg.name %>/**/*.js', 'vendor/**/*.js'],
-          dest: 'dist/sources-<%= pkg.version %>/'
-        }, {
-          expand: true,
-          src: ['wrap/*', 'vendor/**/*.js'],
-          dest: 'dist/sources-<%= pkg.version %>/'
-        }]
-      }
-    },
-
-    uglify: {
-      library: {
-        options: {
-          sourceMapIn: 'dist/<%= pkg.name %>-<%= pkg.version %>.amd.js.map',
-          sourceMap: 'dist/<%= pkg.name %>-<%= pkg.version %>.amd.min.js.map',
-          sourceMappingURL: '<%= pkg.name %>-<%= pkg.version %>.amd.min.js.map'
-        },
-        files: {
-          'dist/<%= pkg.name %>-<%= pkg.version %>.amd.min.js': ['dist/<%= pkg.name %>-<%= pkg.version %>.amd.js']
-        }
-      },
-      browser: {
-        options: {
-          sourceMapIn: 'dist/<%= pkg.name %>-<%= pkg.version %>.js.map',
-          sourceMap: 'dist/<%= pkg.name %>-<%= pkg.version %>.min.js.map',
-          sourceMappingURL: '<%= pkg.name %>-<%= pkg.version %>.min.js.map'
-        },
-        files: {
-          'dist/<%= pkg.name %>-<%= pkg.version %>.min.js': ['dist/<%= pkg.name %>-<%= pkg.version %>.js']
-        }
-      }
-    },
-
-    jshint: {
-      library: 'lib/**/*.js',
-      tests: 'test/tests/**/*.js',
-      options: {
-        jshintrc: '.jshintrc'
-      }
-    },
-
-    clean: ["dist", "tmp"],
 
     qunit: {
-      all: ['test/index.html']
+      all: ['tmp/test/index.html']
     }
-  });
-
-  // Load tasks from npm
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-connect');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-contrib-qunit');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-es6-module-transpiler');
-  grunt.loadNpmTasks('grunt-concat-sourcemap');
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-
-  // Multi-task for wrapping browser version
-  this.registerTask('bytes', function() {
-    console.log("TODO: Add a bytes-tracking task");
-  });
-
-  this.registerMultiTask('fix_sourcemap', "Remove tmp from source paths", function() {
-    var root = this.data.root;
-    this.files.forEach(function(f) {
-      f.src.forEach(function (src) {
-        map = JSON.parse(grunt.file.read(src));
-        for (var i=0; i<map.sources.length; i++) {
-          map.sources[i] = map.sources[i].replace(/tmp\//, '');
-          if (root) {
-            map.sources[i] = grunt.config.process(root) + '/' + map.sources[i];
-          }
-        }
-        grunt.file.write(src, JSON.stringify(map));
-      }, this);
-    });
   });
 };

--- a/package.json
+++ b/package.json
@@ -14,17 +14,23 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "devDependencies": {
+    "broccoli": "0.12.0",
+    "broccoli-cli": "0.0.1",
+    "broccoli-concat": "0.0.6",
+    "broccoli-es6-module-transpiler": "~0.1.0",
+    "broccoli-export-tree": "~0.3.0",
+    "broccoli-file-creator": "~0.1.0",
+    "broccoli-file-mover": "~0.2.0",
+    "broccoli-file-remover": "~0.2.0",
+    "broccoli-jshint": "~0.4.0",
+    "broccoli-kitchen-sink-helpers": "~0.2.0",
+    "broccoli-merge-trees": "0.1.3",
+    "broccoli-static-compiler": "0.1.4",
+    "broccoli-uglify-js": "~0.1.3",
     "grunt": "~0.4.2",
+    "grunt-broccoli": "~0.2.2",
     "grunt-cli": "~0.1.11",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-connect": "~0.6.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-contrib-qunit": "~0.3.0",
-    "grunt-es6-module-transpiler": "~0.6.0",
-    "grunt-concat-sourcemap": "~0.4.0",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-jshint": "~0.8.0",
-    "connect-redirection": "0.0.1"
+    "grunt-contrib-qunit": "~0.4.0"
   }
 }

--- a/tasks/build/browser.js
+++ b/tasks/build/browser.js
@@ -1,0 +1,47 @@
+var pickFiles = require('broccoli-static-compiler');
+var concatFiles = require('broccoli-concat');
+var mergeTrees = require('broccoli-merge-trees');
+var transpileES6 = require('broccoli-es6-module-transpiler');
+var jsHint = require('broccoli-jshint');
+
+var lib = 'lib';
+
+var tests = pickFiles('test', {
+  srcDir: '/tests',
+  destDir: '/htmlbars/tests'
+});
+
+var src = mergeTrees([lib, tests]);
+
+var jsHintTests = jsHint(src, {
+  destFile: '/htmlbars/tests/jshint-test.js'
+});
+
+src = mergeTrees([src, jsHintTests]);
+
+var transpiled = transpileES6(src, { moduleName: true });
+var concatted = concatFiles(transpiled, {
+  inputFiles: ['**/*.js'],
+  outputFile: '/htmlbars-and-tests.amd.js'
+});
+
+// Testing assets
+
+var vendor = pickFiles('vendor', {
+  srcDir: '/',
+  destDir: '/vendor'
+});
+
+var qunit = pickFiles('test', {
+  srcDir: '/',
+  files: ['qunit.js', 'qunit.css'],
+  destDir: '/'
+});
+
+var qunitIndex = pickFiles('test', {
+  srcDir: '/',
+  files: ['index.html'],
+  destDir: '/'
+});
+
+module.exports = mergeTrees([concatted, vendor, qunitIndex, qunit]);

--- a/tasks/build/dist.js
+++ b/tasks/build/dist.js
@@ -1,0 +1,36 @@
+var pickFiles = require('broccoli-static-compiler');
+var moveFile = require('broccoli-file-mover');
+var concatFiles = require('broccoli-concat');
+var mergeTrees = require('broccoli-merge-trees');
+var transpileES6 = require('broccoli-es6-module-transpiler');
+var uglify = require('broccoli-uglify-js');
+
+var path = require('path');
+var pkg = require(path.join(__dirname, '../../package.json'));
+
+var lib = 'lib';
+
+// Named and concatenated AMD
+
+var transpiledAMD = transpileES6(lib, { moduleName: true });
+
+var namedAMD = concatFiles(transpiledAMD, {
+  inputFiles: ['**/*.js'],
+  outputFile: '/htmlbars.amd.js'
+});
+
+// Add package version to filename
+
+var fullNameDist = moveFile(namedAMD, {
+  srcFile: 'htmlbars.amd.js',
+  destFile: 'htmlbars-' + pkg.version + '.amd.js'
+});
+
+// Uglify
+
+var uglifiedDist = uglify(moveFile(namedAMD, {
+  srcFile: 'htmlbars.amd.js',
+  destFile: 'htmlbars-' + pkg.version + '.amd.min.js'
+}));
+
+module.exports = mergeTrees([fullNameDist, uglifiedDist]);

--- a/test/index.html
+++ b/test/index.html
@@ -9,16 +9,14 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <script src="qunit.js"></script>
-  <script src="../vendor/loader.js"></script>
-  <script src="../vendor/handlebars.amd.js"></script>
-  <script src="../vendor/simple-html-tokenizer.amd.js"></script>
-  <script src="../tmp/htmlbars.amd.js"></script>
-  <script src="../tmp/tests.amd.js"></script>
+  <script src="vendor/loader.js"></script>
+  <script src="vendor/handlebars.amd.js"></script>
+  <script src="vendor/simple-html-tokenizer.amd.js"></script>
+  <script src="htmlbars-and-tests.amd.js"></script>
   <script type="text/javascript">
-
-  for (var key in requireModule.registry) {
-    if (/^tests\//.test(key)) requireModule(key);
-  }
+    for (var key in requireModule.registry) {
+      if (/^htmlbars\/tests\//.test(key)) requireModule(key);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
Rewrite build system in Grunt + Broccoli. We currently only use Grunt for grunt-contrib-qunit and we will be able to go full Broccoli once we move the tests over to a DOM abstraction like jsdom.

Paired with @jdjkelly on this.
