### PR TITLE
Add `test/support` directory, shared `equalHTML` assertion

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -24,13 +24,17 @@ function getPackageTrees(packageName) {
   });
 
   // Tests
+  var testSupports = pickFiles('test/support', {
+    srcDir: '/',
+    destDir: '/test/support'
+  });
   var tests = pickFiles('packages/' + packageName + '/tests', {
     srcDir: '/',
     destDir: '/' + packageName + '-tests'
   });
   var jsHintLib = jsHint(lib, { destFile: '/' + packageName + '-jshint/lib.js' });
   var jsHintTests = jsHint(tests, { destFile: '/' + packageName + '-jshint/tests.js' });
-  var allTests = mergeTrees([tests, jsHintLib, jsHintTests]);
+  var allTests = mergeTrees([testSupports, tests, jsHintLib, jsHintTests]);
   var transpiledTests = transpileES6(allTests, { moduleName: true });
   var concatenatedTests = concatFiles(transpiledTests, {
     inputFiles: ['**/*.js'],

--- a/packages/htmlbars-compiler/tests/fragment_test.js
+++ b/packages/htmlbars-compiler/tests/fragment_test.js
@@ -5,13 +5,7 @@ import { HydrationCompiler } from "htmlbars-compiler/compiler/hydration";
 import { domHelpers } from "htmlbars-runtime/dom_helpers";
 import { Morph } from "morph";
 import { preprocess } from "htmlbars-compiler/parser";
-
-function equalHTML(fragment, html) {
-  var div = document.createElement("div");
-  div.appendChild(fragment.cloneNode(true));
-
-  QUnit.push(div.innerHTML === html, div.innerHTML, html);
-}
+import { equalHTML } from "test/support/assertions";
 
 var dom = domHelpers();
 

--- a/packages/htmlbars-compiler/tests/template_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/template_compiler_test.js
@@ -1,15 +1,9 @@
 import { TemplateCompiler } from "htmlbars-compiler/compiler/template";
 import { Morph } from "morph";
 import { preprocess } from "htmlbars-compiler/parser";
+import { equalHTML } from "test/support/assertions";
 
 module("TemplateCompiler");
-
-function equalHTML(fragment, html) {
-  var div = document.createElement("div");
-  div.appendChild(fragment.cloneNode(true));
-
-  QUnit.push(div.innerHTML === html, div.innerHTML, html);
-}
 
 var dom = {
   createDocumentFragment: function () {

--- a/packages/morph/tests/morph_test.js
+++ b/packages/morph/tests/morph_test.js
@@ -1,4 +1,5 @@
 import { Morph } from "morph";
+import { equalHTML } from "test/support/assertions";
 import SafeString from 'handlebars/safe-string';
 
 function morphTests(factory) {
@@ -240,13 +241,6 @@ function morphListTests(factory) {
     equal(morphs[1].before, morphs[0]);
     equal(morphs[1].after,  null);
   });
-}
-
-function equalHTML(fragment, html) {
-  var div = document.createElement("div");
-  div.appendChild(fragment.cloneNode(true));
-
-  QUnit.push(div.innerHTML === html, div.innerHTML, html);
 }
 
 function fragmentFor() {

--- a/test/support/assertions.js
+++ b/test/support/assertions.js
@@ -1,0 +1,6 @@
+export function equalHTML(fragment, html) {
+  var div = document.createElement("div");
+  div.appendChild(fragment.cloneNode(true));
+
+  QUnit.push(div.innerHTML === html, div.innerHTML, html);
+}


### PR DESCRIPTION
Update the `Brocfile` to build a `test/support` directory as ES6 modules, making them available to tests.
