### PR TITLE
Introduce Testem

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,21 @@ info on how HTMLBars is structured and its approach to efficiently building / em
 
 # How to Run Tests
 
-## In Node
+## Via testem
+
+[Testem](https://github.com/airportyh/testem) is a tool for running tests against
+multiple launchers. For instance, Chrome and PhantomJS.
+
+1. Install Testem: `node install -g testem`
+2. Run testem: `testem` or run Testem with specific browers: `testem -l Safari,Firefox`
+
+Testem is a CI tool, so it will run tests as you change files.
+
+## On the console with PhantomJS
 
 1. Run `npm test`.
 
-## In the browser
+## In a browser
 
 1. Run `npm start`.
 2. Visit <http://localhost:4200/test>.

--- a/bin/build.js
+++ b/bin/build.js
@@ -23,6 +23,9 @@ builder.build()
   .then(function() {
     console.log(chalk.green('Built project successfully. Stored in "' + buildPath + '/".\n'));
   })
+  .finally(function() {
+    return builder.cleanup();
+  })
   .catch(function(err) {
     console.log(chalk.red('Build failed.\n'));
 
@@ -30,7 +33,5 @@ builder.build()
       console.log('File: ' + err.file + '\n');
     }
     console.log(err.stack);
-  })
-  .finally(function() {
-    return builder.cleanup();
+    process.exit(1);
   });

--- a/test/index.html
+++ b/test/index.html
@@ -9,6 +9,7 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <script src="qunit.js"></script>
+  <script src="/testem.js"></script>
   <script src="loader.js"></script>
   <script src="packages-config.js"></script>
 

--- a/testem.json
+++ b/testem.json
@@ -1,0 +1,16 @@
+{
+  "framework": "qunit",
+  "test_page": "dist/test/index.html",
+  "before_tests": "node bin/build.js",
+  "watch_files": [
+    "packages/**/*.js",
+    "test/**/*.js"
+  ],
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ],
+  "launch_in_ci": [
+    "PhantomJS"
+  ]
+}


### PR DESCRIPTION
Add Testem as an option for running tests. For example,

``` JavaScript
testem -l Chrome,Firefox,Safari,PhantomJS
```

Will run tests in all these environments in a continuous-build style. If you connect to the URL in the Testem output you can run the tests in any JavaScript-running browser:

![](https://api.monosnap.com/image/download?id=yQXgZmlphb6jp6oDnFAm0OJKk4fceP)

The existing PhantomJS script has not been removed, since [it runs tests against packages separately instead of together](https://github.com/tildeio/htmlbars/commit/4af5862f27ca453a56e76b9f8f6b592d5e5a255f), something I'm not sure we could easily do with Testem short of changing the QUnit runner.
