### PR TITLE
Only pick required test files into dist

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -67,6 +67,7 @@ var handlebars = pickFiles(bower, {
 
 var test = pickFiles('test', {
   srcDir: '/',
+  files: [ 'index.html', 'packages-config.js' ],
   destDir: '/test'
 });
 


### PR DESCRIPTION
The new `support/` directory has been pulling into `dist/`. This stops that.

/cc @mmun
