### PR TITLE
Update simple-html-tokenizer to 231aa960e613

### DIFF
--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -90,6 +90,12 @@ test("Simple elements can have attributes", function() {
   equalHTML(fragment, '<div class="foo" id="bar">content</div>');
 });
 
+test("Simple elements can have arbitrary attributes", function() {
+  var template = compile("<div data-some-data='foo' data-isCamelCase='bar'>content</div>");
+  var fragment = template({}, env);
+  equalHTML(fragment, '<div data-some-data="foo" data-iscamelcase="bar">content</div>');
+});
+
 function shouldBeVoid(tagName) {
   var html = "<" + tagName + " data-foo='bar'><p>hello</p>";
   var template = compile(html);

--- a/vendor/simple-html-tokenizer.amd.js
+++ b/vendor/simple-html-tokenizer.amd.js
@@ -79,7 +79,7 @@ define("simple-html-tokenizer",
       },
 
       addToAttributeName: function(char) {
-        this.token.addToAttributeName(char.toLowerCase());
+        this.token.addToAttributeName(char);
       },
 
       addToAttributeValue: function(char) {
@@ -261,8 +261,6 @@ define("simple-html-tokenizer",
             this.state = 'selfClosingStartTag';
           } else if (char === ">") {
             return this.emitToken();
-          } else if (isUpper(char)) {
-            this.token.addToTagName(char.toLowerCase());
           } else {
             this.token.addToTagName(char);
           }


### PR DESCRIPTION
Update simple html tokenizer to allow mixed case attribute and element names. This is needed for `<linearGradient>` and `<svg viewBox="0 0 0 0">`. Test the current behavior on HTML is unchanged, SVG tests will assert that the case is preserved in a later PR.
