### PR TITLE
Drop un-used hydrate function from main runtime

### DIFF
--- a/packages/htmlbars-runtime/lib/main.js
+++ b/packages/htmlbars-runtime/lib/main.js
@@ -1,6 +1,5 @@
 import { domHelpers } from "./dom_helpers";
 import { Morph } from "./morph";
 
-export function hydrate(spec, options) {
-  return spec(domHelpers(options && options.extensions), Morph);
-}
+export var domHelpers;
+export var Morph;


### PR DESCRIPTION
The hydrate function exported by main is not used. I'm not sure anything is used except for the imports themselves.
