### PR TITLE
Remove opcode rewrites in favor of tracking a solo root state

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/fragment.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment.js
@@ -30,20 +30,6 @@ FragmentCompiler.prototype.endFragment = function() {
   this.source.push('  return el0;\n');
 };
 
-FragmentCompiler.prototype.openRootElement = function(tagName) {
-  this.source.push('  var el0 = '+this.domHelper+'.createElement('+
-    string(tagName)+
-  ');\n');
-};
-
-FragmentCompiler.prototype.closeRootElement = function() {
-  this.source.push('  return el0;\n');
-};
-
-FragmentCompiler.prototype.rootText = function(str) {
-  this.source.push('  return '+this.domHelper+'.createTextNode('+string(str)+');\n');
-};
-
 FragmentCompiler.prototype.openContextualElement = function(domHelper) {
   var el = 'el'+this.depth;
   this.source.push('  '+domHelper+' = new '+this.domHelper+'.constructor('+el+');\n');
@@ -53,8 +39,13 @@ FragmentCompiler.prototype.selectDOMHelper = function(domHelper) {
   this.domHelper = domHelper;
 };
 
-FragmentCompiler.prototype.openElement = function(tagName) {
-  var el = 'el'+(++this.depth);
+FragmentCompiler.prototype.openElement = function(tagName, isRoot) {
+  var el;
+  if (isRoot) {
+    el = 'el0';
+  } else {
+    el = 'el'+(++this.depth);
+  }
   this.source.push('  var '+el+' = '+this.domHelper+'.createElement('+
     string(tagName)+
   ');\n');
@@ -65,13 +56,21 @@ FragmentCompiler.prototype.setAttribute = function(name, value) {
   this.source.push('  '+this.domHelper+'.setAttribute('+el+','+string(name)+','+string(value)+');\n');
 };
 
-FragmentCompiler.prototype.text = function(str) {
-  var el = 'el'+this.depth;
-  this.source.push('  '+this.domHelper+'.appendText('+el+','+string(str)+');\n');
+FragmentCompiler.prototype.text = function(str, isRoot) {
+  if (isRoot) {
+    this.source.push('  return '+this.domHelper+'.createTextNode('+string(str)+');\n');
+  } else {
+    var el = 'el'+this.depth;
+    this.source.push('  '+this.domHelper+'.appendText('+el+','+string(str)+');\n');
+  }
 };
 
-FragmentCompiler.prototype.closeElement = function() {
-  var child = 'el'+(this.depth--);
-  var el = 'el'+this.depth;
-  this.source.push('  '+this.domHelper+'.appendChild('+el+', '+child+');\n');
+FragmentCompiler.prototype.closeElement = function(tagName, isRoot) {
+  if (isRoot) {
+    this.source.push('  return el0;\n');
+  } else {
+    var child = 'el'+(this.depth--);
+    var el = 'el'+this.depth;
+    this.source.push('  '+this.domHelper+'.appendChild('+el+', '+child+');\n');
+  }
 };

--- a/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
@@ -18,8 +18,8 @@ FragmentOpcodeCompiler.prototype.opcode = function(type, params) {
   this.opcodes.push([type, params]);
 };
 
-FragmentOpcodeCompiler.prototype.text = function(text) {
-  this.opcode('text', [text.chars]);
+FragmentOpcodeCompiler.prototype.text = function(text, i, l, isRoot) {
+  this.opcode('text', [text.chars, isRoot]);
 };
 
 FragmentOpcodeCompiler.prototype.openContextualElement = function(domHelper) {
@@ -30,16 +30,14 @@ FragmentOpcodeCompiler.prototype.selectDOMHelper = function(domHelper) {
   this.opcode('selectDOMHelper', [domHelper]);
 };
 
-FragmentOpcodeCompiler.prototype.openElement = function(element) {
-  this.opcode('openElement', [element.tag]);
+FragmentOpcodeCompiler.prototype.openElement = function(element, i, l, isRoot) {
+  this.opcode('openElement', [element.tag, isRoot]);
 
-  element.attributes.forEach(function(attribute) {
-    this.attribute(attribute);
-  }, this);
+  element.attributes.forEach(this.attribute, this);
 };
 
-FragmentOpcodeCompiler.prototype.closeElement = function(element) {
-  this.opcode('closeElement', [element.tag]);
+FragmentOpcodeCompiler.prototype.closeElement = function(element, i, l, isRoot) {
+  this.opcode('closeElement', [element.tag, isRoot]);
 };
 
 FragmentOpcodeCompiler.prototype.startProgram = function(program) {
@@ -54,16 +52,7 @@ FragmentOpcodeCompiler.prototype.endProgram = function(program) {
 
   if (statements.length === 0) {
     this.opcode('empty');
-  } else if (statements.length === 1) {
-    var statement = statements[0];
-    if (statement.type === 'text') {
-      this.opcodes[0][0] = 'rootText';
-    } else if (statement.type === 'element') {
-      var opcodes = this.opcodes;
-      opcodes[0][0] = 'openRootElement';
-      opcodes[opcodes.length-1][0] = 'closeRootElement';
-    }
-  } else {
+  } else if (statements.length > 1) {
     this.opcode('endFragment');
   }
 };

--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -82,14 +82,14 @@ TemplateCompiler.prototype.endProgram = function(program) {
   this.templates.push(template);
 };
 
-TemplateCompiler.prototype.openElement = function(element, i, l, c) {
-  this.fragmentOpcodeCompiler.openElement(element, i, l, c);
-  this.hydrationOpcodeCompiler.openElement(element, i, l, c);
+TemplateCompiler.prototype.openElement = function(element, i, l, isRoot, c) {
+  this.fragmentOpcodeCompiler.openElement(element, i, l, isRoot, c);
+  this.hydrationOpcodeCompiler.openElement(element, i, l, isRoot, c);
 };
 
-TemplateCompiler.prototype.closeElement = function(element, i, l) {
-  this.fragmentOpcodeCompiler.closeElement(element, i, l);
-  this.hydrationOpcodeCompiler.closeElement(element, i, l);
+TemplateCompiler.prototype.closeElement = function(element, i, l, isRoot) {
+  this.fragmentOpcodeCompiler.closeElement(element, i, l, isRoot);
+  this.hydrationOpcodeCompiler.closeElement(element, i, l, isRoot);
 };
 
 TemplateCompiler.prototype.openContextualElement = function(contextualElement) {
@@ -120,9 +120,9 @@ TemplateCompiler.prototype.block = function(block, i, l) {
   this.hydrationOpcodeCompiler.block(block, i, l);
 };
 
-TemplateCompiler.prototype.text = function(string, i, l) {
-  this.fragmentOpcodeCompiler.text(string, i, l);
-  this.hydrationOpcodeCompiler.text(string, i, l);
+TemplateCompiler.prototype.text = function(string, i, l, isRoot) {
+  this.fragmentOpcodeCompiler.text(string, i, l, isRoot);
+  this.hydrationOpcodeCompiler.text(string, i, l, isRoot);
 };
 
 TemplateCompiler.prototype.mustache = function (mustache, i, l) {

--- a/packages/htmlbars-compiler/tests/template_action_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/template_action_compiler_test.js
@@ -30,10 +30,10 @@ test("basic", function() {
   var input = "foo{{bar}}<div></div>";
   actionsEqual(input, [
     ['startProgram', [0]],
-    ['text', [0, 3]],
+    ['text', [0, 3, false]],
     ['mustache', [1, 3]],
-    ['openElement', [2, 3, 0]],
-    ['closeElement', [2, 3]],
+    ['openElement', [2, 3, false, 0]],
+    ['closeElement', [2, 3, false]],
     ['endProgram', []]
   ]);
 });
@@ -42,14 +42,14 @@ test("nested HTML", function() {
   var input = "<a></a><a><a><a></a></a></a>";
   actionsEqual(input, [
     ['startProgram', [0]],
-    ['openElement', [0, 2, 0]],
-    ['closeElement', [0, 2]],
-    ['openElement', [1, 2, 0]],
-    ['openElement', [0, 1, 0]],
-    ['openElement', [0, 1, 0]],
-    ['closeElement', [0, 1]],
-    ['closeElement', [0, 1]],
-    ['closeElement', [1, 2]],
+    ['openElement', [0, 2, false, 0]],
+    ['closeElement', [0, 2, false]],
+    ['openElement', [1, 2, false, 0]],
+    ['openElement', [0, 1, false, 0]],
+    ['openElement', [0, 1, false, 0]],
+    ['closeElement', [0, 1, false]],
+    ['closeElement', [0, 1, false]],
+    ['closeElement', [1, 2, false]],
     ['endProgram', []]
   ]);
 });
@@ -58,19 +58,19 @@ test("mustaches are counted correctly", function() {
   var input = "<a><a>{{foo}}</a><a {{foo}}><a>{{foo}}</a><a>{{foo}}</a></a></a>";
   actionsEqual(input, [
     ['startProgram', [0]],
-    ['openElement', [0, 1, 2]],
-    ['openElement', [0, 2, 1]],
+    ['openElement', [0, 1, true, 2]],
+    ['openElement', [0, 2, false, 1]],
     ['mustache', [0, 1]],
-    ['closeElement', [0, 2]],
-    ['openElement', [1, 2, 3]],
-    ['openElement', [0, 2, 1]],
+    ['closeElement', [0, 2, false]],
+    ['openElement', [1, 2, false, 3]],
+    ['openElement', [0, 2, false, 1]],
     ['mustache', [0, 1]],
-    ['closeElement', [0, 2]],
-    ['openElement', [1, 2, 1]],
+    ['closeElement', [0, 2, false]],
+    ['openElement', [1, 2, false, 1]],
     ['mustache', [0, 1]],
-    ['closeElement', [1, 2]],
-    ['closeElement', [1, 2]],
-    ['closeElement', [0, 1]],
+    ['closeElement', [1, 2, false]],
+    ['closeElement', [1, 2, false]],
+    ['closeElement', [0, 1, true]],
     ['endProgram', []]
   ]);
 });
@@ -81,9 +81,9 @@ test("empty block", function() {
     ['startProgram', [0]],
     ['endProgram', []],
     ['startProgram', [1]],
-    ['text', [0, 3]],
+    ['text', [0, 3, false]],
     ['block', [1, 3]],
-    ['text', [2, 3]],
+    ['text', [2, 3, false]],
     ['endProgram', []]
   ]);
 });
@@ -94,12 +94,12 @@ test("block with inverse", function() {
     ['startProgram', [0]],
     ['endProgram', []],
     ['startProgram', [0]],
-    ['text', [0, 1]],
+    ['text', [0, 1, true]],
     ['endProgram', []],
     ['startProgram', [2]],
-    ['text', [0, 3]],
+    ['text', [0, 3, false]],
     ['block', [1, 3]],
-    ['text', [2, 3]],
+    ['text', [2, 3, false]],
     ['endProgram', []]
   ]);
 });
@@ -108,30 +108,30 @@ test("nested blocks", function() {
   var input = "{{#a}}{{#a}}<b></b>{{/a}}{{#a}}{{b}}{{/a}}{{/a}}{{#a}}b{{/a}}";
   actionsEqual(input, [
     ['startProgram', [0]],
-    ['text', [0, 1]],
+    ['text', [0, 1, true]],
     ['endProgram', []],
     ['startProgram', [0]],
-    ['text', [0, 3]],
+    ['text', [0, 3, false]],
     ['mustache', [1, 3]],
-    ['text', [2, 3]],
+    ['text', [2, 3, false]],
     ['endProgram', []],
     ['startProgram', [0]],
-    ['openElement', [0, 1, 0]],
-    ['closeElement', [0, 1]],
+    ['openElement', [0, 1, true, 0]],
+    ['closeElement', [0, 1, true]],
     ['endProgram', []],
     ['startProgram', [2]],
-    ['text', [0, 5]],
+    ['text', [0, 5, false]],
     ['block', [1, 5]],
-    ['text', [2, 5]],
+    ['text', [2, 5, false]],
     ['block', [3, 5]],
-    ['text', [4, 5]],
+    ['text', [4, 5, false]],
     ['endProgram', []],
     ['startProgram', [2]],
-    ['text', [0, 5]],
+    ['text', [0, 5, false]],
     ['block', [1, 5]],
-    ['text', [2, 5]],
+    ['text', [2, 5, false]],
     ['block', [3, 5]],
-    ['text', [4, 5]],
+    ['text', [4, 5, false]],
     ['endProgram', []]
   ]);
 });
@@ -140,12 +140,12 @@ test("web component", function() {
   var input = "<x-foo>bar</x-foo>";
   actionsEqual(input, [
     ['startProgram', [0]],
-    ['text', [0, 1]],
+    ['text', [0, 1, true]],
     ['endProgram', []],
     ['startProgram', [1]],
-    ['text', [0, 3]],
+    ['text', [0, 3, false]],
     ['component', [1, 3]],
-    ['text', [2, 3]],
+    ['text', [2, 3, false]],
     ['endProgram', []]
   ]);
 });


### PR DESCRIPTION
These changes remove the opcode rewrites for root elements and `shareParent` `popParent` `consumeParent` steps. Instead, they determine if the element is a root element in the template visitor and pass that state as an argument to the opcode calls.
