### PR TITLE
Add namespaces to AST in the token handler

### DIFF
--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -22,6 +22,29 @@ voidTagNames.split(" ").forEach(function(tagName) {
   voidMap[tagName] = true;
 });
 
+var svgNamespace = "http://www.w3.org/2000/svg",
+    // http://www.w3.org/html/wg/drafts/html/master/syntax.html#html-integration-point
+    svgHTMLIntegrationPoints = ['foreignObject', 'desc', 'title'];
+
+function applyNamespace(tag, element, currentElement){
+  if (tag.tagName === 'svg') {
+    element.namespaceURI = svgNamespace;
+  } else if (
+    currentElement.type === 'element' &&
+    currentElement.namespaceURI &&
+    !currentElement.isHTMLIntegrationPoint
+  ) {
+    element.namespaceURI = currentElement.namespaceURI;
+  }
+}
+
+function applyHTMLIntegrationPoint(tag, element){
+  if (svgHTMLIntegrationPoints.indexOf(tag.tagName) !== -1) {
+    element.isHTMLIntegrationPoint = true;
+  }
+}
+
+
 // Except for `mustache`, all tokens are only allowed outside of
 // a start or end tag.
 var tokenHandlers = {
@@ -34,6 +57,8 @@ var tokenHandlers = {
 
   StartTag: function(tag) {
     var element = new ElementNode(tag.tagName, tag.attributes, tag.helpers || [], []);
+    applyNamespace(tag, element, this.currentElement());
+    applyHTMLIntegrationPoint(tag, element);
     this.elementStack.push(element);
     if (voidMap.hasOwnProperty(tag.tagName) || tag.selfClosing) {
       tokenHandlers.EndTag.call(this, tag);


### PR DESCRIPTION
This decorates the AST with namespace and HTML integration point flags. This will allow us to emit opcodes that can be compiled into a series of DOMHelper (as in #50) objects that swap in and out appropriately for a template's fragments and hydration.
