### PR TITLE
Support self-closing elements

### DIFF
--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -11,6 +11,10 @@ var states = {
   "beforeAttributeName": "in-tag"
 };
 
+// The HTML elements in this list are speced by
+// http://www.w3.org/TR/html-markup/syntax.html#syntax-elements,
+// and will be forced to close regardless of if they have a
+// self-closing /> at the end.
 var voidTagNames = "area base br col command embed hr img input keygen link meta param source track wbr";
 var voidMap = {};
 
@@ -31,7 +35,7 @@ var tokenHandlers = {
   StartTag: function(tag) {
     var element = new ElementNode(tag.tagName, tag.attributes, tag.helpers || [], []);
     this.elementStack.push(element);
-    if (voidMap.hasOwnProperty(tag.tagName)) {
+    if (voidMap.hasOwnProperty(tag.tagName) || tag.selfClosing) {
       tokenHandlers.EndTag.call(this, tag);
     }
   },

--- a/packages/htmlbars-compiler/tests/combined_ast_test.js
+++ b/packages/htmlbars-compiler/tests/combined_ast_test.js
@@ -107,6 +107,13 @@ test("a simple piece of content", function() {
   ]));
 });
 
+test("self-closed element", function() {
+  var t = '<g />';
+  astEqual(t, root([
+    element("g")
+  ]));
+});
+
 test("a piece of content with HTML", function() {
   var t = 'some <div>content</div> done';
   astEqual(t, root([


### PR DESCRIPTION
Allow tags to be self-closed. This is extracted from #51.
