### PR TITLE
Compiler now ignores comment nodes instead of shitting itself

### DIFF
--- a/packages/htmlbars-compiler/lib/html-parser/node-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/node-handlers.js
@@ -60,6 +60,10 @@ var nodeHelpers = {
   mustache: function(mustache) {
     switchToHandlebars(this);
     this.acceptToken(mustache);
+  },
+
+  comment: function(comment) {
+    return;
   }
 
 };

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -140,6 +140,10 @@ test("The compiler can handle newlines", function() {
   ok(true);
 });
 
+test("The compiler can handle comments", function() {
+  compilesTo("<div>{{! Better not break! }}content</div>", '<div>content</div>', {});
+});
+
 test("The compiler can handle simple handlebars", function() {
   compilesTo('<div>{{title}}</div>', '<div>hello</div>', { title: 'hello' });
 });


### PR DESCRIPTION
Before, the compiler would outright fail when it encountered a handlebars style comment.

Also, I should ask, what is the plan for partials? {{>"partial-name"}} Are these going to be the new syntax for components or will they be kept separate?
