### PR TITLE
Move options configuration into hydration

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/helpers.js
+++ b/packages/htmlbars-compiler/lib/compiler/helpers.js
@@ -24,7 +24,7 @@ export function prepareHelper(stack, size) {
   var programId = stack.pop();
   var inverseId = stack.pop();
 
-  var options = ['types:' + array(types), 'hashTypes:' + hash(hashTypes), 'hash:' + hash(hashPairs)];
+  var options = ['context:context', 'types:' + array(types), 'hashTypes:' + hash(hashTypes), 'hash:' + hash(hashPairs)];
 
   if (programId !== null) {
     options.push('render:child' + programId);

--- a/packages/htmlbars-compiler/lib/compiler/hydration.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration.js
@@ -70,6 +70,7 @@ prototype.stackLiteral = function(literal) {
 prototype.helper = function(name, size, escaped, morphNum) {
   var prepared = prepareHelper(this.stack, size);
   prepared.options.push('escaped:'+escaped);
+  prepared.options.push('morph:morph'+morphNum);
   this.pushMustacheInContent(string(name), prepared.args, prepared.options, morphNum);
 };
 
@@ -93,14 +94,11 @@ prototype.ambiguousAttr = function(str, escaped) {
 prototype.helperAttr = function(name, size, escaped) {
   var prepared = prepareHelper(this.stack, size);
   prepared.options.push('escaped:'+escaped);
-
   this.stack.push('['+string(name)+','+prepared.args+','+ hash(prepared.options)+']');
 };
 
 prototype.sexpr = function(name, size) {
   var prepared = prepareHelper(this.stack, size);
-
-  //export function subexpr(helperName, context, params, options) {
   this.stack.push('hooks.subexpr(' + string(name) + ', context, ' + prepared.args + ', ' + hash(prepared.options) + ', ' + this.envHash() + ')');
 };
 
@@ -110,6 +108,7 @@ prototype.string = function(str) {
 
 prototype.nodeHelper = function(name, size, elementNum) {
   var prepared = prepareHelper(this.stack, size);
+  prepared.options.push('element:element'+elementNum);
   this.pushMustacheInNode(string(name), prepared.args, prepared.options, elementNum);
 };
 

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -4,7 +4,6 @@ import SafeString from 'handlebars/safe-string';
 export function content(morph, helperName, context, params, options, env) {
   var value, helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    options.context = context;
     value = helper(params, options, env);
   } else {
     value = this.simple(context, helperName, options);
@@ -18,7 +17,6 @@ export function content(morph, helperName, context, params, options, env) {
 export function webComponent(morph, tagName, context, options, env) {
   var value, helper = this.lookupHelper(tagName, context, options);
   if (helper) {
-    options.context = context;
     value = helper(null, options, env);
   } else {
     value = this.webComponentFallback(morph, tagName, context, options, env);
@@ -44,8 +42,6 @@ export function webComponentFallback(morph, tagName, context, options, env) {
 export function element(domElement, helperName, context, params, options, env) {
   var helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    options.context = context;
-    options.element = domElement;
     helper(params, options, env);
   }
 }
@@ -70,7 +66,6 @@ export function concat(params, options, env) {
 export function subexpr(helperName, context, params, options, env) {
   var helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    options.context = context;
     return helper(params, options, env);
   } else {
     return this.simple(context, helperName, options);


### PR DESCRIPTION
options.{context,morph,element} are now set in the hydration compiler instead of in the hooks.
