### PR TITLE
Pass contextual element directly to morph

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/fragment.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment.js
@@ -4,14 +4,13 @@ import { string } from "./quoting";
 export function FragmentCompiler() {
   this.source = [];
   this.depth = -1;
-  this.domHelper = 'dom0';
 }
 
 FragmentCompiler.prototype.compile = function(opcodes) {
   this.source.length = 0;
-  this.depth = 0;
+  this.depth = -1;
 
-  this.source.push('function build() {\n');
+  this.source.push('function build(dom) {\n');
   processOpcodes(this, opcodes);
   this.source.push('}\n');
 
@@ -20,17 +19,17 @@ FragmentCompiler.prototype.compile = function(opcodes) {
 
 FragmentCompiler.prototype.createFragment = function() {
   var el = 'el'+(++this.depth);
-  this.source.push('  var '+el+' = '+this.domHelper+'.createDocumentFragment();\n');
+  this.source.push('  var '+el+' = dom.createDocumentFragment();\n');
 };
 
 FragmentCompiler.prototype.createElement = function(tagName) {
   var el = 'el'+(++this.depth);
-  this.source.push('  var '+el+' = '+this.domHelper+'.createElement('+string(tagName)+');\n');
+  this.source.push('  var '+el+' = dom.createElement('+string(tagName)+');\n');
 };
 
 FragmentCompiler.prototype.createText = function(str) {
   var el = 'el'+(++this.depth);
-  this.source.push('  var '+el+' = '+this.domHelper+'.createTextNode('+string(str)+');\n');
+  this.source.push('  var '+el+' = dom.createTextNode('+string(str)+');\n');
 };
 
 FragmentCompiler.prototype.returnNode = function() {
@@ -40,20 +39,11 @@ FragmentCompiler.prototype.returnNode = function() {
 
 FragmentCompiler.prototype.setAttribute = function(name, value) {
   var el = 'el'+this.depth;
-  this.source.push('  '+this.domHelper+'.setAttribute('+el+','+string(name)+','+string(value)+');\n');
-};
-
-FragmentCompiler.prototype.createDOMHelper = function(domHelper) {
-  var el = 'el'+this.depth;
-  this.source.push('  '+domHelper+' = new '+this.domHelper+'.constructor('+el+');\n');
-};
-
-FragmentCompiler.prototype.selectDOMHelper = function(domHelper) {
-  this.domHelper = domHelper;
+  this.source.push('  dom.setAttribute('+el+','+string(name)+','+string(value)+');\n');
 };
 
 FragmentCompiler.prototype.appendChild = function() {
   var child = 'el'+(this.depth--);
   var el = 'el'+this.depth;
-  this.source.push('  '+this.domHelper+'.appendChild('+el+', '+child+');\n');
+  this.source.push('  dom.appendChild('+el+', '+child+');\n');
 };

--- a/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
@@ -23,14 +23,6 @@ FragmentOpcodeCompiler.prototype.text = function(text, childIndex, childCount, i
   if (!isSingleRoot) { this.opcode('appendChild'); }
 };
 
-FragmentOpcodeCompiler.prototype.openContextualElement = function(domHelper) {
-  this.opcode('createDOMHelper', [domHelper]);
-};
-
-FragmentOpcodeCompiler.prototype.selectDOMHelper = function(domHelper) {
-  this.opcode('selectDOMHelper', [domHelper]);
-};
-
 FragmentOpcodeCompiler.prototype.openElement = function(element) {
   this.opcode('createElement', [element.tag]);
   element.attributes.forEach(this.attribute, this);

--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -39,10 +39,6 @@ HydrationOpcodeCompiler.prototype.text = function(string) {
   ++this.currentDOMChildIndex;
 };
 
-HydrationOpcodeCompiler.prototype.selectDOMHelper = function(domHelper) {
-  this.opcode('selectDOMHelper', domHelper);
-};
-
 HydrationOpcodeCompiler.prototype.openElement = function(element, pos, len, isSingleRoot, mustacheCount) {
   distributeMorphs(this.morphs, this.opcodes);
   ++this.currentDOMChildIndex;

--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -13,8 +13,6 @@ export function TemplateCompiler() {
   this.hydrationCompiler = new HydrationCompiler();
   this.templates = [];
   this.childTemplates = [];
-  this.domHelperStack = [];
-  this.domHelperVariables = [];
 }
 
 TemplateCompiler.prototype.compile = function(ast) {
@@ -29,11 +27,6 @@ TemplateCompiler.prototype.compile = function(ast) {
 TemplateCompiler.prototype.startProgram = function(program, childTemplateCount) {
   this.fragmentOpcodeCompiler.startProgram(program, childTemplateCount);
   this.hydrationOpcodeCompiler.startProgram(program, childTemplateCount);
-
-  // The stack tracks what the current helper is
-  this.domHelperStack.splice(0, this.domHelperStack.length, 'dom0');
-  // The list of variables
-  this.domHelperVariables.splice(0, this.domHelperVariables.length, 'dom0');
 
   this.childTemplates.length = 0;
   while(childTemplateCount--) {
@@ -63,17 +56,17 @@ TemplateCompiler.prototype.endProgram = function(program) {
   var template =
     '(function (){\n' +
       childTemplateVars +
-    'var ' + this.domHelperVariables.join(', ') + ';\n' +
       fragmentProgram +
     'var cachedFragment;\n' +
-    'return function template(context, env) {\n' +
-    '  if (!env.dom) { throw "You must specify a dom argument to env"; }\n' +
-    '  if (dom0 === undefined || !dom0.sameAs(env.dom)) {\n' +
-    '    dom0 = env.dom;\n' +
-    '    cachedFragment = build();\n' +
+    'return function template(context, env, contextualElement) {\n' +
+    '  var dom = env.dom, hooks = env.hooks;\n' +
+    '  if (cachedFragment === undefined) {\n' +
+    '    cachedFragment = build(dom);\n' +
     '  }\n' +
-    '  var fragment = dom0.cloneNode(cachedFragment, true);\n' +
-    '  var hooks = env.hooks;\n' +
+    '  if (contextualElement === undefined) {\n' +
+    '    contextualElement = dom.document.body;\n' +
+    '  }\n' +
+    '  var fragment = dom.cloneNode(cachedFragment, true);\n' +
        hydrationProgram +
     '  return fragment;\n' +
     '};\n' +
@@ -90,24 +83,6 @@ TemplateCompiler.prototype.openElement = function(element, i, l, r, c) {
 TemplateCompiler.prototype.closeElement = function(element, i, l, r) {
   this.fragmentOpcodeCompiler.closeElement(element, i, l, r);
   this.hydrationOpcodeCompiler.closeElement(element, i, l, r);
-};
-
-TemplateCompiler.prototype.openContextualElement = function(contextualElement) {
-  var previousHelper = this.domHelperStack[this.domHelperStack.length-1],
-      domHelper      = 'dom'+this.domHelperVariables.length;
-  this.domHelperStack.push(domHelper);
-  this.domHelperVariables.push(domHelper);
-
-  this.fragmentOpcodeCompiler.openContextualElement(domHelper);
-  this.fragmentOpcodeCompiler.selectDOMHelper(domHelper);
-  this.hydrationOpcodeCompiler.selectDOMHelper(domHelper);
-};
-
-TemplateCompiler.prototype.closeContextualElement = function(contextualElement) {
-  this.domHelperStack.pop();
-  var domHelper = this.domHelperStack[this.domHelperStack.length-1];
-  this.fragmentOpcodeCompiler.selectDOMHelper(domHelper);
-  this.hydrationOpcodeCompiler.selectDOMHelper(domHelper);
 };
 
 TemplateCompiler.prototype.component = function(component, i, l) {

--- a/packages/htmlbars-compiler/lib/compiler/template_visitor.js
+++ b/packages/htmlbars-compiler/lib/compiler/template_visitor.js
@@ -138,14 +138,7 @@ TemplateVisitor.prototype.block = function(node) {
   var parentNode = frame.parentNode;
 
   frame.mustacheCount++;
-  
-  if (parentNode.type === 'element') {
-    frame.actions.push(['closeContextualElement', [parentNode]]);
-    frame.actions.push([node.type, [node, frame.childIndex, frame.childCount]]);
-    frame.actions.push(['openContextualElement', [parentNode]]);
-  } else {
-    frame.actions.push([node.type, [node, frame.childIndex, frame.childCount]]);
-  }
+  frame.actions.push([node.type, [node, frame.childIndex, frame.childCount]]);
 
   if (node.inverse) { this.visit(node.inverse); }
   if (node.program) { this.visit(node.program); }

--- a/packages/htmlbars-compiler/tests/template_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/template_compiler_test.js
@@ -5,7 +5,7 @@ import { DOMHelper } from "morph";
 
 module("TemplateCompiler");
 
-var dom = new DOMHelper(null, document);
+var dom = new DOMHelper();
 
 var hooks = {
   content: function(morph, helperName, context, params, options, env) {

--- a/packages/morph/lib/morph.js
+++ b/packages/morph/lib/morph.js
@@ -1,6 +1,6 @@
 var splice = Array.prototype.splice;
 
-function Morph(parent, start, end, domHelper) {
+function Morph(parent, start, end, domHelper, contextualElement) {
   // TODO: this is an internal API, this should be an assert
   if (parent.nodeType === 11) {
     if (start === null || end === null) {
@@ -14,6 +14,7 @@ function Morph(parent, start, end, domHelper) {
   this.start = start;
   this.end = end;
   this.domHelper = domHelper;
+  this.contextualElement = contextualElement || parent;
   this.text = null;
   this.owner = null;
   this.morphs = null;
@@ -22,11 +23,11 @@ function Morph(parent, start, end, domHelper) {
   this.escaped = true;
 }
 
-Morph.create = function (parent, startIndex, endIndex, domHelper) {
+Morph.create = function (parent, startIndex, endIndex, domHelper, contextualElement) {
   var childNodes = parent.childNodes,
       start = startIndex === -1 ? null : childNodes[startIndex],
       end = endIndex === -1 ? null : childNodes[endIndex];
-  return new Morph(parent, start, end, domHelper);
+  return new Morph(parent, start, end, domHelper, contextualElement);
 };
 
 Morph.prototype.parent = function () {
@@ -136,7 +137,7 @@ Morph.prototype._updateHTML = function (parent, html) {
   var start = this.start, end = this.end;
   clear(parent, start, end);
   this.text = null;
-  var childNodes = this.domHelper.parseHTML(html, parent);
+  var childNodes = this.domHelper.parseHTML(html, this.contextualElement);
   appendChildren(parent, end, childNodes);
   if (this.before !== null) {
     this.before.end = start.nextSibling;

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -4,33 +4,38 @@ import {equalHTML} from "test/support/assertions";
 var xhtmlNamespace = "http://www.w3.org/1999/xhtml",
     svgNamespace   = "http://www.w3.org/2000/svg";
 
-module('htmlbars-runtime: DOM Helper');
+var dom;
+
+module('htmlbars-runtime: DOM Helper', {
+  setup: function() {
+    dom = new DOMHelper();
+  },
+  teardown: function() {
+    dom = null;
+  }
+});
 
 test('#createElement', function(){
-  var dom = new DOMHelper(null, document),
-      node = dom.createElement('div');
+  var node = dom.createElement('div');
   equal(node.tagName, 'DIV');
   equal(node.namespaceURI, xhtmlNamespace);
   equalHTML(node, '<div></div>');
 });
 
 test('#appendText adds text', function(){
-  var dom = new DOMHelper(null, document),
-      node = dom.createElement('div');
+  var node = dom.createElement('div');
   dom.appendText(node, 'Howdy');
   equalHTML(node, '<div>Howdy</div>');
 });
 
 test('#setAttribute', function(){
-  var dom = new DOMHelper(null, document),
-      node = dom.createElement('div');
+  var node = dom.createElement('div');
   dom.setAttribute(node, 'id', 'super-tag');
   equalHTML(node, '<div id="super-tag"></div>');
 });
 
 test('#createElement of tr with contextual table element', function(){
   var tableElement = document.createElement('table'),
-      dom = new DOMHelper(tableElement),
       node = dom.createElement('tr');
   equal(node.tagName, 'TR');
   equal(node.namespaceURI, xhtmlNamespace);
@@ -39,17 +44,17 @@ test('#createElement of tr with contextual table element', function(){
 
 test('#parseHTML of tr with contextual table element', function(){
   var tableElement = document.createElement('table'),
-      dom = new DOMHelper(tableElement),
-      nodes = dom.parseHTML('<tr><td>Yo</td></tr>', document.createDocumentFragment());
+      nodes = dom.parseHTML('<tr><td>Yo</td></tr>', tableElement);
   equal(nodes[0].tagName, 'TBODY');
   equal(nodes[0].childNodes[0].tagName, 'TR');
   equal(nodes[0].namespaceURI, xhtmlNamespace);
   equal(nodes[0].childNodes[0].namespaceURI, xhtmlNamespace);
 });
 
+// TODO: Basic svg support
+/*
 test('#createElement of svg with svg namespace', function(){
-  var dom = new DOMHelper(null, document, svgNamespace),
-      node = dom.createElement('svg');
+  var node = dom.createElement('svg');
   equal(node.tagName, 'svg');
   equal(node.namespaceURI, svgNamespace);
   equalHTML(node, '<svg></svg>');
@@ -57,19 +62,18 @@ test('#createElement of svg with svg namespace', function(){
 
 test('#createElement of path with svg contextual element', function(){
   var svgElement = document.createElementNS(svgNamespace, 'svg'),
-      dom = new DOMHelper(svgElement),
       node = dom.createElement('path');
   equal(node.tagName, 'path');
   equal(node.namespaceURI, svgNamespace);
   equalHTML(node, '<path></path>');
 });
+*/
 
 // TODO: Safari, Phantom do not return childNodes for SVG
 /*
 test('#parseHTML of path with svg contextual element', function(){
   var svgElement = document.createElementNS(svgNamespace, 'svg'),
-      dom = new DOMHelper(svgElement),
-      nodes = dom.parseHTML('<path></path>', document.createDocumentFragment());
+      nodes = dom.parseHTML('<path></path>', svgElement);
   console.log(nodes);
   equal(nodes[0].tagName, 'path');
   equal(nodes[0].namespaceURI, svgNamespace);
@@ -81,8 +85,7 @@ test('#cloneNode shallow', function(){
 
   divElement.appendChild( document.createElement('span') );
 
-  var dom = new DOMHelper(null, document),
-      node = dom.cloneNode(divElement, false);
+  var node = dom.cloneNode(divElement, false);
 
   equal(node.tagName, 'DIV');
   equal(node.namespaceURI, xhtmlNamespace);
@@ -94,8 +97,7 @@ test('#cloneNode deep', function(){
 
   divElement.appendChild( document.createElement('span') );
 
-  var dom = new DOMHelper(null, document),
-      node = dom.cloneNode(divElement, true);
+  var node = dom.cloneNode(divElement, true);
 
   equal(node.tagName, 'DIV');
   equal(node.namespaceURI, xhtmlNamespace);


### PR DESCRIPTION
This PR simplifies domHelpers (removes a lot of code) by reusing the same DOMHelper instance and passing contextual elements to morphs. It temporarily removes some namespacing work. There's a plan to bring them back.

/cc @mixonic
