### PR TITLE
Setting an attribute to null (and only null) removes that attribute

### DIFF
--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -107,6 +107,13 @@ test("Simple elements can have attributes", function() {
   equalTokens(fragment, '<div class="foo" id="bar">content</div>');
 });
 
+test("Null attribute value removes that attribute", function() {
+  var template = compile('<input disabled="{{isDisabled}}">');
+  var fragment =template({isDisabled: null}, env);
+
+  equalTokens(fragment, '<input>');
+});
+
 test("Simple elements can have arbitrary attributes", function() {
   var template = compile("<div data-some-data='foo' data-isCamelCase='bar'>content</div>");
   var fragment = template({}, env);

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -47,7 +47,14 @@ export function element(domElement, helperName, context, params, options, env) {
 }
 
 export function attribute(params, options, env) {
-  options.element.setAttribute(params[0], params[1]);
+  var attrName = params[0];
+  var attrValue = params[1];
+
+  if (attrValue === null) {
+    options.element.removeAttribute(attrName);
+  } else {
+    options.element.setAttribute(attrName, attrValue);
+  }
 }
 
 export function concat(params, options, env) {


### PR DESCRIPTION
Small change to ensure that null attribute values _remove_ those attributes.

Example template: `<input disabled="{{isDisabled}}">`. When `isDisabled` is null (and only null), the output is `<input>`. Any other value will insert that as the attribute's value in the output.

This addresses #68

This also paves the way to add a `{{boolean-attribute}}` helper
