### PR TITLE
SVG support

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/fragment.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment.js
@@ -48,3 +48,7 @@ FragmentCompiler.prototype.appendChild = function() {
   var el = 'el'+this.depth;
   this.source.push(this.indent+'  dom.appendChild('+el+', '+child+');\n');
 };
+
+FragmentCompiler.prototype.setNamespace = function(namespace) {
+  this.source.push(this.indent+'  dom.setNamespace('+(namespace ? string(namespace) : 'null')+');\n');
+};

--- a/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
@@ -55,4 +55,8 @@ FragmentOpcodeCompiler.prototype.attribute = function(attr) {
   }
 };
 
+FragmentOpcodeCompiler.prototype.setNamespace = function(namespace) {
+  this.opcode('setNamespace', [namespace]);
+};
+
 export { FragmentOpcodeCompiler };

--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -67,6 +67,7 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     indent+'  var cachedFragment;\n' +
     indent+'  return function template(context, env, contextualElement) {\n' +
     indent+'    var dom = env.dom, hooks = env.hooks;\n' +
+    indent+'    dom.detectNamespace(contextualElement);\n' +
     indent+'    if (cachedFragment === undefined) {\n' +
     indent+'      cachedFragment = build(dom);\n' +
     indent+'    }\n' +
@@ -107,4 +108,8 @@ TemplateCompiler.prototype.text = function(string, i, l, r) {
 TemplateCompiler.prototype.mustache = function (mustache, i, l) {
   this.fragmentOpcodeCompiler.mustache(mustache, i, l);
   this.hydrationOpcodeCompiler.mustache(mustache, i, l);
+};
+
+TemplateCompiler.prototype.setNamespace = function(namespace) {
+  this.fragmentOpcodeCompiler.setNamespace(namespace);
 };

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -3,6 +3,9 @@ import { tokenize } from "simple-html-tokenizer";
 import { hydrationHooks } from "htmlbars-runtime/hooks";
 import { DOMHelper } from "morph";
 
+var xhtmlNamespace = "http://www.w3.org/1999/xhtml",
+    svgNamespace   = "http://www.w3.org/2000/svg";
+
 function frag(element, string) {
   if (element instanceof DocumentFragment) {
     element = document.createElement('div');
@@ -60,11 +63,12 @@ module("HTML-based compiler (output)", {
 
 function equalTokens(fragment, html) {
   var div = document.createElement("div");
-
   div.appendChild(fragment.cloneNode(true));
-
   var fragTokens = tokenize(div.innerHTML);
-  var htmlTokens = tokenize(html);
+
+  div.removeChild(div.childNodes[0]);
+  div.innerHTML = html;
+  var htmlTokens = tokenize(div.innerHTML);
 
   function normalizeTokens(token) {
     if (token.type === 'StartTag') {
@@ -109,7 +113,7 @@ test("Simple elements can have attributes", function() {
 
 test("Null attribute value removes that attribute", function() {
   var template = compile('<input disabled="{{isDisabled}}">');
-  var fragment =template({isDisabled: null}, env);
+  var fragment = template({isDisabled: null}, env);
 
   equalTokens(fragment, '<input>');
 });
@@ -118,6 +122,19 @@ test("Simple elements can have arbitrary attributes", function() {
   var template = compile("<div data-some-data='foo'>content</div>");
   var fragment = template({}, env);
   equalTokens(fragment, '<div data-some-data="foo">content</div>');
+});
+
+test("checked attribute and checked property are present after clone and hydrate", function() {
+  var template = compile("<input checked=\"checked\">");
+  var fragment = template({}, env);
+  ok(fragment.checked, 'input is checked');
+  equalTokens(fragment, "<input checked='checked'>");
+});
+
+test("SVG element can have capitalized attributes", function() {
+  var template = compile("<svg viewBox=\"0 0 0 0\"></svg>");
+  var fragment = template({}, env);
+  equalTokens(fragment, '<svg viewBox=\"0 0 0 0\"></svg>');
 });
 
 test("checked attribute and checked property are present after clone and hydrate", function() {
@@ -154,6 +171,69 @@ test("Void elements are self-closing", function() {
 
 test("The compiler can handle nesting", function() {
   var html = '<div class="foo"><p><span id="bar" data-foo="bar">hi!</span></p></div> More content';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equalTokens(fragment, html);
+});
+
+test("The compiler can handle namespaced elements", function() {
+  var html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equal(fragment.namespaceURI, svgNamespace, "creates the svg element with a namespace");
+  equalTokens(fragment, html);
+});
+
+test("The compiler sets namespaces on nested namespaced elements", function() {
+  var html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+         "creates the path element with a namespace" );
+  equalTokens(fragment, html);
+});
+
+test("The compiler sets a namespace on an HTML integration point", function() {
+  var html = '<svg><foreignObject>Hi</foreignObject></svg>';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equal( fragment.namespaceURI, svgNamespace,
+         "creates the path element with a namespace" );
+  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+         "creates the path element with a namespace" );
+  equalTokens(fragment, html);
+});
+
+test("The compiler does not set a namespace on an element inside an HTML integration point", function() {
+  var html = '<svg><foreignObject><div></div></foreignObject></svg>';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equal( fragment.childNodes[0].childNodes[0].namespaceURI, xhtmlNamespace,
+         "creates the path element with a namespace" );
+  equalTokens(fragment, html);
+});
+
+test("The compiler pops back to the correct namespace", function() {
+  var html = '<svg></svg><svg></svg><div></div>';
+  var template = compile(html);
+  var fragment = template({}, env);
+
+  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+         "creates the path element with a namespace" );
+  equal( fragment.childNodes[1].namespaceURI, svgNamespace,
+         "creates the path element with a namespace" );
+  equal( fragment.childNodes[2].namespaceURI, xhtmlNamespace,
+         "creates the path element with a namespace" );
+  equalTokens(fragment, html);
+});
+
+test("The compiler preserves capitalization of tags", function() {
+  var html = '<svg><linearGradient id="gradient"></linearGradient></svg>';
   var template = compile(html);
   var fragment = template({}, env);
 
@@ -768,6 +848,104 @@ test("Data-bound block helpers", function() {
   equalTokens(fragment, '<p>hi</p> content  more <em>content</em> here');
 });
 */
+
+test("svg can live with hydration", function() {
+  var template = compile('<svg></svg>{{name}}');
+
+  var fragment = template({ name: 'Milly' }, env);
+  equal(
+    fragment.childNodes[0].namespaceURI, svgNamespace,
+    "svg namespace inside a block is present" );
+});
+
+test("svg can take some hydration", function() {
+  var template = compile('<div><svg>{{name}}</svg></div>');
+
+  var fragment = template({ name: 'Milly' }, env);
+  equal(
+    fragment.childNodes[0].namespaceURI, svgNamespace,
+    "svg namespace inside a block is present" );
+  equalTokens( fragment, '<div><svg>Milly</svg></div>',
+             "html is valid" );
+});
+
+test("root svg can take some hydration", function() {
+  var template = compile('<svg>{{name}}</svg>');
+  var fragment = template({ name: 'Milly' }, env);
+  equal(
+    fragment.namespaceURI, svgNamespace,
+    "svg namespace inside a block is present" );
+  equalTokens( fragment, '<svg>Milly</svg>',
+             "html is valid" );
+});
+
+test("Block helper allows interior namespace", function() {
+  var isTrue = true;
+  hooks.content = function(morph, path, context, params, options, env) {
+    if (isTrue) {
+      morph.update(options.render(context, env, morph.contextualElement));
+    } else {
+     morph.update(options.inverse(context, env, morph.contextualElement));
+    }
+  };
+  var template = compile('{{#testing}}<svg></svg>{{else}}<div><svg></svg></div>{{/testing}}');
+
+  var fragment = template({ isTrue: true }, env);
+  equal(
+    fragment.childNodes[1].namespaceURI, svgNamespace,
+    "svg namespace inside a block is present" );
+
+  isTrue = false;
+  fragment = template({ isTrue: false }, env);
+  equal(
+    fragment.childNodes[1].namespaceURI, xhtmlNamespace,
+    "inverse block path has a normal namespace");
+  equal(
+    fragment.childNodes[1].childNodes[0].namespaceURI, svgNamespace,
+    "svg namespace inside an element inside a block is present" );
+});
+
+test("Block helper allows namespace to bleed through", function() {
+  hooks.content = function(morph, path, context, params, options, env) {
+    morph.update(options.render(context, env, morph.contextualElement));
+  };
+
+  var template = compile('<div><svg>{{#testing}}<circle />{{/testing}}</svg></div>');
+
+  var fragment = template({ isTrue: true }, env);
+  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+         "svg tag has an svg namespace" );
+  equal( fragment.childNodes[0].childNodes[0].namespaceURI, svgNamespace,
+         "circle tag inside block inside svg has an svg namespace" );
+});
+
+test("Block helper with root svg allows namespace to bleed through", function() {
+  hooks.content = function(morph, path, context, params, options, env) {
+    morph.update(options.render(context, env, morph.contextualElement));
+  };
+
+  var template = compile('<svg>{{#testing}}<circle />{{/testing}}</svg>');
+
+  var fragment = template({ isTrue: true }, env);
+  equal( fragment.namespaceURI, svgNamespace,
+         "svg tag has an svg namespace" );
+  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+         "circle tag inside block inside svg has an svg namespace" );
+});
+
+test("Block helper with root foreignObject allows namespace to bleed through", function() {
+  hooks.content = function(morph, path, context, params, options, env) {
+    morph.update(options.render(context, env, morph.contextualElement));
+  };
+
+  var template = compile('<foreignObject>{{#testing}}<div></div>{{/testing}}</foreignObject>');
+
+  var fragment = template({ isTrue: true }, env, document.createElementNS(svgNamespace, 'svg'));
+  equal( fragment.namespaceURI, svgNamespace,
+         "foreignObject tag has an svg namespace" );
+  equal( fragment.childNodes[0].namespaceURI, xhtmlNamespace,
+         "div inside morph and foreignObject has xhtml namespace" );
+});
 
 test("Node helpers can modify the node", function() {
   registerHelper('testing', function(params, options) {

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -35,7 +35,7 @@ export function webComponentFallback(morph, tagName, context, options, env) {
       element.setAttribute(name, hash[name]);
     }
   }
-  element.appendChild(options.render(context, env));
+  element.appendChild(options.render(context, env, morph.contextualElement));
   return element;
 }
 

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -76,33 +76,35 @@ test('#parseHTML of tr with contextual table element', function(){
 });
 
 // TODO: Basic svg support
-/*
 test('#createElement of svg with svg namespace', function(){
+  dom.setNamespace(svgNamespace);
   var node = dom.createElement('svg');
   equal(node.tagName, 'svg');
   equal(node.namespaceURI, svgNamespace);
-  equalHTML(node, '<svg></svg>');
 });
 
 test('#createElement of path with svg contextual element', function(){
-  var svgElement = document.createElementNS(svgNamespace, 'svg'),
-      node = dom.createElement('path');
+  dom.setNamespace(svgNamespace);
+  var node = dom.createElement('path');
   equal(node.tagName, 'path');
   equal(node.namespaceURI, svgNamespace);
-  equalHTML(node, '<path></path>');
 });
-*/
 
-// TODO: Safari, Phantom does not return childNodes for SVG
-/*
 test('#parseHTML of path with svg contextual element', function(){
+  dom.setNamespace(svgNamespace);
   var svgElement = document.createElementNS(svgNamespace, 'svg'),
       nodes = dom.parseHTML('<path></path>', svgElement);
-  console.log(nodes);
-  equal(nodes[0].tagName, 'path');
+  equal(nodes[0].tagName.toLowerCase(), 'path');
   equal(nodes[0].namespaceURI, svgNamespace);
 });
-*/
+
+test('#parseHTML of stop with linearGradient contextual element', function(){
+  dom.setNamespace(svgNamespace);
+  var svgElement = document.createElementNS(svgNamespace, 'linearGradient'),
+      nodes = dom.parseHTML('<stop />', svgElement);
+  equal(nodes[0].tagName.toLowerCase(), 'stop');
+  equal(nodes[0].namespaceURI, svgNamespace);
+});
 
 test('#cloneNode shallow', function(){
   var divElement = document.createElement('div');


### PR DESCRIPTION
This SVG approach builds on earlier commits. I wrote it on top of the IE patch then rebased it back down to master. So either PR can go first.

When a template is run, the namespace is detected from the `contextualElement`. If a `contextualElement` is not provided, there is a chance the root elements will be created with the wrong namespace. During fragment build, if there is a new namespace that child elements expect, then `setNamespace` is called. The `DOMHelper` is dumb about state, it just keeps track of the last namespace. Doing this in the compiled output will perform better than checking the parent element every time we do a `createElement`.

For SVG to work seamlessly between templates, helpers must pass the `contextualElement` to `render`.

``` JavaScript
options.render(context, env, morph.contextualElement);
```

Simple template output.

``` JavaScript
(function() {
  function build(dom) {
    var el0 = dom.createElement("div");
    dom.setNamespace("http://www.w3.org/2000/svg");
    var el1 = dom.createElement("svg");
    var el2 = dom.createElement("circle");
    dom.appendChild(el1, el2);
    var el2 = dom.createElement("desc");
    dom.setNamespace(null);
    var el3 = dom.createElement("span");
    dom.appendChild(el2, el3);
    dom.appendChild(el1, el2);
    dom.appendChild(el0, el1);
    return el0;
  }
  var cachedFragment;
  return function template(context, env, contextualElement) {
    var dom = env.dom, hooks = env.hooks;
    dom.detectNamespace(contextualElement);
    if (cachedFragment === undefined) {
      cachedFragment = build(dom);
    }
    var fragment = dom.cloneNode(cachedFragment, true);
    return fragment;
  };
}());
```
