### PR TITLE
Use copy-dereference instead of deprecated copyRecursivelySync

### DIFF
--- a/bin/build.js
+++ b/bin/build.js
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 
-var mkdir = require('fs').mkdir;
 var rimraf = require('rimraf').sync;
 var chalk = require('chalk');
 var broccoli = require('broccoli');
-var copyRecursivelySync = require('broccoli-kitchen-sink-helpers').copyRecursivelySync;
+var copyDereferenceSync = require('copy-dereference').sync;
 
 process.env.BROCCOLI_ENV = process.env.BROCCOLI_ENV || 'production';
 var tree = broccoli.loadBrocfile();
@@ -17,8 +16,7 @@ console.log('Building HTMLBars "' + process.env.BROCCOLI_ENV + '" to "' + buildP
 builder.build()
   .then(function(results) {
     rimraf(buildPath);
-    mkdir(buildPath);
-    copyRecursivelySync(results.directory, buildPath);
+    copyDereferenceSync(results.directory, buildPath);
   })
   .then(function() {
     console.log(chalk.green('Built project successfully. Stored in "' + buildPath + '/".\n'));

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "broccoli-export-tree": "~0.3.0",
     "broccoli-file-mover": "~0.3.2",
     "broccoli-jshint": "~0.4.0",
-    "broccoli-kitchen-sink-helpers": "~0.2.2",
+    "copy-dereference": "~1.0.0",
     "broccoli-merge-trees": "0.1.3",
     "broccoli-replace": "~0.1.6",
     "broccoli-static-compiler": "0.1.4",


### PR DESCRIPTION
We've deprecated `copyRecursivelySync` in favor of the node-copy-dereference package.

I've verified that the build output in `dist` stays the same byte-by-byte with this change.
