### PR TITLE
parseHTML disregards browser generated omitted start tags

### DIFF
--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -290,8 +290,8 @@ test("The compiler can handle top-level unescaped tr", function() {
                  }, document.createElement('table'));
 
   equal(
-    fragment.childNodes[1].tagName, 'TBODY',
-    "root tr has been wrapped in tbody" );
+    fragment.childNodes[1].tagName, 'TR',
+    "root tr is present" );
 });
 
 test("The compiler can handle top-level unescaped td inside tr contextualElement", function() {
@@ -326,8 +326,8 @@ test("The compiler can handle unescaped tr in top of content", function() {
                  }, document.createElement('table'));
 
   equal(
-    fragment.childNodes[2].tagName, 'TBODY',
-    "root tr has been wrapped in tbody" );
+    fragment.childNodes[2].tagName, 'TR',
+    "root tr is present" );
 });
 
 test("The compiler can handle unescaped tr inside fragment table", function() {
@@ -348,8 +348,8 @@ test("The compiler can handle unescaped tr inside fragment table", function() {
                  }, document.createElement('div'));
 
   equal(
-    fragment.childNodes[1].tagName, 'TBODY',
-    "root tr has been wrapped in tbody" );
+    fragment.childNodes[1].tagName, 'TR',
+    "root tr is present" );
 });
 
 test("The compiler can handle simple helpers", function() {

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -91,16 +91,37 @@ test('#insertMorphBefore', function(){
   equal(element.innerHTML, 'abc');
 });
 
-test('#parseHTML of tr with contextual table element', function(){
+test('#parseHTML of tr returns a tr inside a table context', function(){
   var tableElement = document.createElement('table'),
       nodes = dom.parseHTML('<tr><td>Yo</td></tr>', tableElement);
-  equal(nodes[0].tagName, 'TBODY');
-  equal(nodes[0].childNodes[0].tagName, 'TR');
+  equal(nodes[0].tagName, 'TR');
   equal(nodes[0].namespaceURI, xhtmlNamespace);
-  equal(nodes[0].childNodes[0].namespaceURI, xhtmlNamespace);
 });
 
-// TODO: Basic svg support
+test('#parseHTML of tr inside tbody returns a tbody', function(){
+  var tableElement = document.createElement('table'),
+      nodes = dom.parseHTML('<tbody><tr></tr></tbody>', tableElement);
+  equal(nodes[0].tagName, 'TBODY');
+  equal(nodes[0].namespaceURI, xhtmlNamespace);
+});
+
+test('#parseHTML of col returns a col inside a table context', function(){
+  var tableElement = document.createElement('table'),
+      nodes = dom.parseHTML('<col></col>', tableElement);
+  equal(nodes[0].tagName, 'COL');
+  equal(nodes[0].namespaceURI, xhtmlNamespace);
+});
+
+test('#parseHTML of script then tr inside table context wraps the tr in a tbody', function(){
+  var tableElement = document.createElement('table'),
+      nodes = dom.parseHTML('<script></script><tr><td>Yo</td></tr>', tableElement);
+  // The HTML spec suggests the first item must be the child of
+  // the omittable start tag. Here script is the first child, so no-go.
+  equal(nodes.length, 2, 'Leading script tag corrupts');
+  equal(nodes[0].tagName, 'SCRIPT');
+  equal(nodes[1].tagName, 'TBODY');
+});
+
 test('#createElement of svg with svg namespace', function(){
   dom.setNamespace(svgNamespace);
   var node = dom.createElement('svg');


### PR DESCRIPTION
The HTML spec allows for "omitted start tags". These tags are optional when their intended child is the first thing in the parent tag. For example, this is a tbody start tag:

```
<table>
  <tbody>
    <tr>
```

The tbody may be omitted, and the browser will accept and render:

```
<table>
  <tr>
```

However, the omitted start tag will still be added to the DOM. We now test the string and context to see if the browser is about to perform this cleanup.

http://www.whatwg.org/specs/web-apps/current-work/multipage/syntax.html#optional-tags

describes which tags are omittable. The spec for tbody and colgroup explains this behavior:

http://www.whatwg.org/specs/web-apps/current-work/multipage/tables.html#the-tbody-element
http://www.whatwg.org/specs/web-apps/current-work/multipage/tables.html#the-colgroup-element

With aid from @bantic. tl;dr the spec will show you the way.

Replaces #89
