### PR TITLE
On postinstall, run bower install, not bower update.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "HTMLBars compiles Handlebars templates into document fragments rather than string buffers",
   "main": "index.js",
   "scripts": {
-    "postinstall": "bower update",
+    "postinstall": "bower install",
     "build": "bin/build.js",
     "pretest": "bin/build.js",
     "test": "bin/run-tests.js",


### PR DESCRIPTION
I think this will fix the broken build, although I'm not sure why the change was made. Commit 922dda732bfe9 suggested that it was to fix the Travis build, but I don't see how.

Edit: to clarify, I mean I don't understand why bower update would be necessary on a Travis build. I assume Travis cleans up the working area between runs. Sorry if this is the wrong approach to the problem.

/cc @krisselden
