### PR TITLE
Optional second argument to createElement detects namespace

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -124,7 +124,10 @@ prototype.setAttribute = function(element, name, value) {
 };
 
 if (document.createElementNS) {
-  prototype.createElement = function(tagName) {
+  prototype.createElement = function(tagName, contextualElement) {
+    if (contextualElement) {
+      this.detectNamespace(contextualElement);
+    }
     if (this.namespace) {
       return this.document.createElementNS(this.namespace, tagName);
     } else {

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -256,9 +256,15 @@ test('#createElement of svg with svg namespace', function(){
   equal(node.namespaceURI, svgNamespace);
 });
 
-test('#createElement of path with svg contextual element', function(){
+test('#createElement of path with detected svg contextual element', function(){
   dom.setNamespace(svgNamespace);
   var node = dom.createElement('path');
+  equal(node.tagName, 'path');
+  equal(node.namespaceURI, svgNamespace);
+});
+
+test('#createElement of path with svg contextual element', function(){
+  var node = dom.createElement('path', document.createElementNS(svgNamespace, 'svg'));
   equal(node.tagName, 'path');
   equal(node.namespaceURI, svgNamespace);
 });


### PR DESCRIPTION
If a contextual element is passed to element creation, detect a namespace
