### PR TITLE
Detect svg as well as internal namespace in createElement

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -125,12 +125,19 @@ prototype.setAttribute = function(element, name, value) {
 };
 
 if (document.createElementNS) {
+  // Only opt into namespace detection if a contextualElement
+  // is passed.
   prototype.createElement = function(tagName, contextualElement) {
+    var namespace = this.namespace;
     if (contextualElement) {
-      this.detectNamespace(contextualElement);
+      if (tagName === 'svg') {
+        namespace = svgNamespace;
+      } else {
+        namespace = interiorNamespace(contextualElement);
+      }
     }
-    if (this.namespace) {
-      return this.document.createElementNS(this.namespace, tagName);
+    if (namespace) {
+      return this.document.createElementNS(namespace, tagName);
     } else {
       return this.document.createElement(tagName);
     }

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -271,6 +271,12 @@ test('#createElement of path with svg contextual element', function(){
   equal(node.namespaceURI, svgNamespace);
 });
 
+test('#createElement of svg with div namespace', function(){
+  var node = dom.createElement('svg', document.createElement('div'));
+  equal(node.tagName, 'svg');
+  equal(node.namespaceURI, svgNamespace);
+});
+
 for (i=0;i<foreignNamespaces.length;i++) {
   foreignNamespace = foreignNamespaces[i];
 


### PR DESCRIPTION
- Avoid mutating `this.namespace` during `createElement`
- Detect SVG tags in addition to the internal namespace detection
