### PR TITLE
A classList based add/removeClass, setAttribute fallback

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -5,6 +5,10 @@ import {
   svgNamespace,
   svgHTMLIntegrationPoints
 } from "./dom-helper/build-html-dom";
+import {
+  addClasses,
+  removeClasses
+} from "./dom-helper/classes";
 
 var doc = typeof document === 'undefined' ? false : document;
 
@@ -154,6 +158,9 @@ if (doc && doc.createElementNS) {
     return this.document.createElement(tagName);
   };
 }
+
+prototype.addClasses = addClasses;
+prototype.removeClasses = removeClasses;
 
 prototype.setNamespace = function(ns) {
   this.namespace = ns;

--- a/packages/morph/lib/dom-helper/classes.js
+++ b/packages/morph/lib/dom-helper/classes.js
@@ -1,0 +1,115 @@
+var doc = typeof document === 'undefined' ? false : document;
+
+// PhantomJS has a broken classList. See https://github.com/ariya/phantomjs/issues/12782
+var canClassList = doc && (function(){
+  var d = document.createElement('div');
+  if (!d.classList) {
+    return false;
+  }
+  d.classList.add('boo');
+  d.classList.add('boo', 'baz');
+  return (d.className === 'boo baz');
+})();
+
+function buildClassList(element) {
+  var classString = (element.getAttribute('class') || '');
+  return classString !== '' && classString !== ' ' ? classString.split(' ') : [];
+}
+
+function intersect(containingArray, valuesArray) {
+  var containingIndex = 0;
+  var containingLength = containingArray.length;
+  var valuesIndex = 0;
+  var valuesLength = valuesArray.length;
+
+  var intersection = new Array(valuesLength);
+
+  // TODO: rewrite this loop in an optimal manner
+  for (;containingIndex<containingLength;containingIndex++) {
+    valuesIndex = 0;
+    for (;valuesIndex<valuesLength;valuesIndex++) {
+      if (valuesArray[valuesIndex] === containingArray[containingIndex]) {
+        intersection[valuesIndex] = containingIndex;
+        break;
+      }
+    }
+  }
+
+  return intersection;
+}
+
+function addClassesViaAttribute(element, classNames) {
+  var existingClasses = buildClassList(element);
+
+  var indexes = intersect(existingClasses, classNames);
+  var didChange = false;
+
+  for (var i=0, l=classNames.length; i<l; i++) {
+    if (indexes[i] === undefined) {
+      didChange = true;
+      existingClasses.push(classNames[i]);
+    }
+  }
+
+  if (didChange) {
+    element.setAttribute('class', existingClasses.length > 0 ? existingClasses.join(' ') : '');
+  }
+}
+
+function removeClassesViaAttribute(element, classNames) {
+  var existingClasses = buildClassList(element);
+
+  var indexes = intersect(classNames, existingClasses);
+  var didChange = false;
+  var newClasses = [];
+
+  for (var i=0, l=existingClasses.length; i<l; i++) {
+    if (indexes[i] === undefined) {
+      newClasses.push(existingClasses[i]);
+    } else {
+      didChange = true;
+    }
+  }
+
+  if (didChange) {
+    element.setAttribute('class', newClasses.length > 0 ? newClasses.join(' ') : '');
+  }
+}
+
+var addClasses, removeClasses;
+if (canClassList) {
+  addClasses = function addClasses(element, classNames) {
+    if (element.classList) {
+      if (classNames.length === 1) {
+        element.classList.add(classNames[0]);
+      } else if (classNames.length === 2) {
+        element.classList.add(classNames[0], classNames[1]);
+      } else {
+        element.classList.add.apply(element.classList, classNames);
+      }
+    } else {
+      addClassesViaAttribute(element, classNames);
+    }
+  };
+  removeClasses = function removeClasses(element, classNames) {
+    if (element.classList) {
+      if (classNames.length === 1) {
+        element.classList.remove(classNames[0]);
+      } else if (classNames.length === 2) {
+        element.classList.remove(classNames[0], classNames[1]);
+      } else {
+        element.classList.remove.apply(element.classList, classNames);
+      }
+    } else {
+      removeClassesViaAttribute(element, classNames);
+    }
+  };
+} else {
+  addClasses = addClassesViaAttribute;
+  removeClasses = removeClassesViaAttribute;
+}
+
+export {
+  addClasses,
+  removeClasses
+};

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -49,6 +49,32 @@ test('#removeAttribute', function(){
   equalHTML(node, '<div></div>', 'attribute was removed');
 });
 
+test('#addClasses', function(){
+  var node = dom.createElement('div');
+  dom.addClasses(node, ['super-fun']);
+  equal(node.className, 'super-fun');
+  dom.addClasses(node, ['super-fun']);
+  equal(node.className, 'super-fun');
+  dom.addClasses(node, ['super-blast']);
+  equal(node.className, 'super-fun super-blast');
+  dom.addClasses(node, ['bacon', 'ham']);
+  equal(node.className, 'super-fun super-blast bacon ham');
+});
+
+test('#removeClasses', function(){
+  var node = dom.createElement('div');
+  node.setAttribute('class', 'this-class that-class');
+  dom.removeClasses(node, ['this-class']);
+  equal(node.className, 'that-class');
+  dom.removeClasses(node, ['this-class']);
+  equal(node.className, 'that-class');
+  dom.removeClasses(node, ['that-class']);
+  equal(node.className, '');
+  node.setAttribute('class', 'woop moop jeep');
+  dom.removeClasses(node, ['moop', 'jeep']);
+  equal(node.className, 'woop');
+});
+
 test('#createElement of tr with contextual table element', function(){
   var tableElement = document.createElement('table'),
       node = dom.createElement('tr', tableElement);
@@ -368,5 +394,27 @@ test('#parseHTML of stop with linearGradient contextual element', function(){
   equal(nodes[0].tagName, 'stop');
   equal(nodes[0].namespaceURI, svgNamespace);
 });
+
+test('#addClasses on SVG', function(){
+  var node = document.createElementNS(svgNamespace, 'svg');
+  dom.addClasses(node, ['super-fun']);
+  equal(node.getAttribute('class'), 'super-fun');
+  dom.addClasses(node, ['super-fun']);
+  equal(node.getAttribute('class'), 'super-fun');
+  dom.addClasses(node, ['super-blast']);
+  equal(node.getAttribute('class'), 'super-fun super-blast');
+});
+
+test('#removeClasses on SVG', function(){
+  var node = document.createElementNS(svgNamespace, 'svg');
+  node.setAttribute('class', 'this-class that-class');
+  dom.removeClasses(node, ['this-class']);
+  equal(node.getAttribute('class'), 'that-class');
+  dom.removeClasses(node, ['this-class']);
+  equal(node.getAttribute('class'), 'that-class');
+  dom.removeClasses(node, ['that-class']);
+  equal(node.getAttribute('class'), '');
+});
+
 
 }


### PR DESCRIPTION
In prep for removing the Ember.js `jQuery` dependency on `.addClass`. By using `classList` (with a `setAttribute` fallback) we also gain better performance and SVG compatibility.
