### PR TITLE
Fix demo

### DIFF
--- a/demos/compile-and-run.html
+++ b/demos/compile-and-run.html
@@ -13,8 +13,6 @@
     <hr>
 
     <script src="../bower_components/loader/loader.js"></script>
-    <script src="../dist/vendor/simple-html-tokenizer.amd.js"></script>
-    <script src="../dist/vendor/handlebars.amd.js"></script>
     <script src="../dist/morph.amd.js"></script>
     <script src="../dist/htmlbars-compiler.amd.js"></script>
     <script src="../dist/htmlbars-runtime.amd.js"></script>
@@ -39,7 +37,7 @@
         try {
           var templateSpec = compileSpec(source),
               template     = compile(source),
-              dom          = template(data, {hooks: hooks, dom: new DOMHelper()});
+              dom          = template(data, {hooks: hooks, dom: new DOMHelper()}, output);
           output.innerHTML = '<pre><code>'+JSON.stringify(data)+'</code></pre><hr><pre><code>'+templateSpec+'</code></pre><hr>';
           output.appendChild(dom);
         } catch(e) {


### PR DESCRIPTION
Following the README install instructions, the demo didn't work.

Seems the `npm run-script build` doesn't generate `/dist/vendor/` files anymore (they 404). I think they get bundled in the `<package>.amd.js` that depends on them.

Also provided template with a context, as it was gving the error `An element node must be provided for a contextualElement, you provided nothing`
