### PR TITLE
Add `NUMBER` to hydration opcode types.

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -209,6 +209,10 @@ HydrationOpcodeCompiler.prototype.INTEGER = function(integer) {
   this.opcode('literal', integer.stringModeValue);
 };
 
+HydrationOpcodeCompiler.prototype.NUMBER = function(number) {
+  this.opcode('literal', number.stringModeValue);
+};
+
 function processParams(compiler, params) {
   forEach(params, function(param) {
     if (param.type === 'text') {

--- a/packages/htmlbars-compiler/tests/hydration_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/hydration_compiler_test.js
@@ -96,13 +96,14 @@ test("back to back mustaches should have a text node inserted between them", fun
 });
 
 test("helper usage", function() {
-  var opcodes = opcodesFor("<div>{{foo 'bar'}}</div>");
+  var opcodes = opcodesFor("<div>{{foo 'bar' 42}}</div>");
   deepEqual(opcodes, [
     [ "morph", [ 0, [0], -1, -1 ] ],
     [ "program", [null, null] ],
     [ "stringLiteral", ['bar'] ],
+    [ "literal", [42] ],
     [ "stackLiteral", [0] ],
-    helper('foo', ['bar'], 0)
+    helper('foo', ['bar', 42], 0)
   ]);
 });
 


### PR DESCRIPTION
Required for `{{log}}` helper.
