### PR TITLE
Embed Handlebars parser into htmlbars-compiler.

### DIFF
--- a/build-support/handlebars-inliner.js
+++ b/build-support/handlebars-inliner.js
@@ -1,0 +1,16 @@
+var path = require('path');
+var Funnel = require('broccoli-funnel');
+
+var files = [
+  'handlebars/exception.js',
+  'handlebars/compiler/ast.js',
+  'handlebars/compiler/base.js',
+  'handlebars/compiler/parser.js'
+];
+
+var root = path.join(__dirname, '..', 'node_modules', 'handlebars', 'lib');
+
+module.exports = new Funnel(root, {
+  files: files,
+  destDir: '/htmlbars-compiler'
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "HTMLBars compiles Handlebars templates into document fragments rather than string buffers",
   "main": "index.js",
   "scripts": {
-    "postinstall": "bower install",
+    "prepublish": "bower install",
     "build": "bin/build.js",
     "pretest": "bin/build.js",
     "test": "bin/run-tests.js",
@@ -17,6 +17,10 @@
   "author": "Tilde, Inc.",
   "license": "MIT",
   "readmeFilename": "README.md",
+  "dependencies": {
+    "handlebars": "1.3.0",
+    "broccoli-funnel": "^0.1.6"
+  },
   "devDependencies": {
     "bower": "~1.3.3",
     "broccoli": "0.12.0",
@@ -26,10 +30,9 @@
     "broccoli-export-tree": "~0.3.0",
     "broccoli-file-mover": "0.3.5",
     "broccoli-file-remover": "~0.2.2",
-    "broccoli-jshint": "~0.4.0",
-    "broccoli-merge-trees": "0.1.3",
+    "broccoli-jshint": "~0.5.3",
+    "broccoli-merge-trees": "0.2.1",
     "broccoli-string-replace": "~0.0.2",
-    "broccoli-static-compiler": "0.1.4",
     "broccoli-uglify-js": "~0.1.3",
     "chalk": "~0.4.0",
     "copy-dereference": "~1.0.0",

--- a/packages/htmlbars-compiler/lib/ast.js
+++ b/packages/htmlbars-compiler/lib/ast.js
@@ -1,4 +1,4 @@
-import AST from "../handlebars/compiler/ast";
+import AST from "./handlebars/compiler/ast";
 
 export var MustacheNode = AST.MustacheNode;
 export var SexprNode = AST.SexprNode;

--- a/packages/htmlbars-compiler/lib/parser.js
+++ b/packages/htmlbars-compiler/lib/parser.js
@@ -1,4 +1,4 @@
-import { parse } from "../handlebars/compiler/base";
+import { parse } from "./handlebars/compiler/base";
 import { Tokenizer } from "../simple-html-tokenizer";
 import nodeHandlers from "./html-parser/node-handlers";
 import tokenHandlers from "./html-parser/token-handlers";

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -1,5 +1,5 @@
 import { merge } from "./utils";
-import SafeString from '../handlebars/safe-string';
+import SafeString from '../htmlbars-util/safe-string';
 
 export function content(morph, helperName, context, params, options, env) {
   var value, helper = this.lookupHelper(helperName, context, options);

--- a/packages/htmlbars-util/lib/main.js
+++ b/packages/htmlbars-util/lib/main.js
@@ -1,0 +1,5 @@
+import SafeString from './htmlbars-util/safe-string';
+
+export {
+  SafeString
+};

--- a/packages/htmlbars-util/lib/safe-string.js
+++ b/packages/htmlbars-util/lib/safe-string.js
@@ -1,0 +1,10 @@
+function SafeString(string) {
+  this.string = string;
+}
+
+SafeString.prototype.toString = function() {
+  return "" + this.string;
+};
+
+export default SafeString;
+

--- a/packages/htmlbars-util/tests/htmlbars-util-test.js
+++ b/packages/htmlbars-util/tests/htmlbars-util-test.js
@@ -1,0 +1,7 @@
+import {SafeString} from "../htmlbars-util";
+
+QUnit.module('htmlbars-util');
+
+test("SafeString is exported", function(){
+  ok(typeof SafeString === 'function', 'SafeString is exported');
+});

--- a/packages/index.js
+++ b/packages/index.js
@@ -32,18 +32,19 @@ module.exports = {
   dependencies: {
     "htmlbars": {
       node: true,
-      lib: ["handlebars", "morph", "simple-html-tokenizer", "htmlbars-compiler", "htmlbars-runtime"]
+      lib: ["handlebars-inliner", "htmlbars-util", "morph", "simple-html-tokenizer", "htmlbars-compiler", "htmlbars-runtime"]
     },
     "htmlbars-compiler": {
       node: true,
-      lib: ["handlebars", "simple-html-tokenizer", "morph"],
+      lib: ["handlebars-inliner", "htmlbars-util", "simple-html-tokenizer", "morph"],
       test: ["htmlbars-runtime"]
     },
+    "htmlbars-util": { },
     "htmlbars-runtime": {
-      lib: ["handlebars", "morph"]
+      lib: ["htmlbars-util", "morph"]
     },
     "morph": {
-      test: ["handlebars"]
+      test: ["htmlbars-util"]
     }
   }
 };

--- a/packages/morph/tests/morph-test.js
+++ b/packages/morph/tests/morph-test.js
@@ -1,6 +1,6 @@
 import Morph from "../morph/morph";
 import { equalHTML, equalInnerHTML } from "../test/support/assertions";
-import SafeString from '../handlebars/safe-string';
+import SafeString from '../htmlbars-util/safe-string';
 import DOMHelper from "../morph/dom-helper";
 
 var domHelper = new DOMHelper();


### PR DESCRIPTION
- Embed required Handlebars parser modules into htmlbars-compiler.
- Migrate to broccoli-funnel instead of broccoli-static-compiler.
- Add htmlbars-utils package for safe-string (otherwise handlebars modules would be needed for most packages).

This allows HTMLBars to be developed independently of specific Handlebars version.  Whatever version is required, will be embedded and downstream consumers do not have to match versions.

Specifically, it allows Ember's test suite (which uses Handlebars 2.0) to use HTMLBars (which requires Handlebars 1.3).
## 

Changes to Ember build system to match this will be in a follow-up Ember PR.
