### PR TITLE
Refactor helper call signature.

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/helpers.js
+++ b/packages/htmlbars-compiler/lib/compiler/helpers.js
@@ -24,7 +24,7 @@ export function prepareHelper(stack, size) {
   var programId = stack.pop();
   var inverseId = stack.pop();
 
-  var options = ['context:context', 'types:' + array(types), 'hashTypes:' + hash(hashTypes), 'hash:' + hash(hashPairs)];
+  var options = ['types:' + array(types), 'hashTypes:' + hash(hashTypes)];
 
   if (programId !== null) {
     options.push('render:child' + programId);
@@ -36,6 +36,7 @@ export function prepareHelper(stack, size) {
 
   return {
     options: options,
-    args: array(args)
+    args: array(args),
+    hash: hash(hashPairs)
   };
 }

--- a/packages/htmlbars-compiler/lib/compiler/hydration.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration.js
@@ -76,21 +76,20 @@ prototype.helper = function(name, size, escaped, morphNum) {
   var prepared = prepareHelper(this.stack, size);
   prepared.options.push('escaped:'+escaped);
   prepared.options.push('morph:morph'+morphNum);
-  this.pushMustacheInContent(string(name), prepared.args, prepared.options, morphNum);
+  this.pushMustacheInContent(string(name), prepared.args, prepared.hash, prepared.options, morphNum);
 };
 
 prototype.component = function(tag, morphNum) {
   var prepared = prepareHelper(this.stack, 0);
   prepared.options.push('morph:morph'+morphNum);
-  this.pushComponent(string(tag), prepared.options, morphNum);
+  this.pushComponent(string(tag), prepared.hash, prepared.options, morphNum);
 };
 
 prototype.ambiguous = function(str, escaped, morphNum) {
   var options = [];
-  options.push('context:context');
   options.push('escaped:'+escaped);
   options.push('morph:morph'+morphNum);
-  this.pushMustacheInContent(string(str), '[]', options, morphNum);
+  this.pushMustacheInContent(string(str), '[]', '{}', options, morphNum);
 };
 
 prototype.ambiguousAttr = function(str, escaped) {
@@ -100,12 +99,12 @@ prototype.ambiguousAttr = function(str, escaped) {
 prototype.helperAttr = function(name, size, escaped) {
   var prepared = prepareHelper(this.stack, size);
   prepared.options.push('escaped:'+escaped);
-  this.stack.push('['+string(name)+','+prepared.args+','+ hash(prepared.options)+']');
+  this.stack.push('['+string(name)+','+prepared.args+','+ prepared.hash +',' + hash(prepared.options)+']');
 };
 
 prototype.sexpr = function(name, size) {
   var prepared = prepareHelper(this.stack, size);
-  this.stack.push('hooks.subexpr(' + string(name) + ', context, ' + prepared.args + ', ' + hash(prepared.options) + ', env)');
+  this.stack.push('hooks.subexpr(' + string(name) + ', context, ' + prepared.args + ', ' + prepared.hash + ',' + hash(prepared.options) + ', env)');
 };
 
 prototype.string = function(str) {
@@ -115,7 +114,7 @@ prototype.string = function(str) {
 prototype.nodeHelper = function(name, size, elementNum) {
   var prepared = prepareHelper(this.stack, size);
   prepared.options.push('element:element'+elementNum);
-  this.pushMustacheInNode(string(name), prepared.args, prepared.options, elementNum);
+  this.pushMustacheInNode(string(name), prepared.args, prepared.hash, prepared.options, elementNum);
 };
 
 prototype.morph = function(num, parentPath, startIndex, endIndex) {
@@ -137,8 +136,8 @@ prototype.element = function(elementNum){
   this.parents[this.parents.length-1] = elementNodesName;
 };
 
-prototype.pushComponent = function(name, pairs, morphNum) {
-  this.source.push(this.indent+'  hooks.component(morph' + morphNum + ', ' + name + ', context, ' + hash(pairs) + ', env);\n');
+prototype.pushComponent = function(name, hashArgs, pairs, morphNum) {
+  this.source.push(this.indent+'  hooks.component(morph' + morphNum + ', ' + name + ', context, ' + hashArgs + ', ' + hash(pairs) + ', env);\n');
 };
 
 prototype.repairClonedNode = function(blankChildTextNodes, isElementChecked) {
@@ -152,12 +151,12 @@ prototype.repairClonedNode = function(blankChildTextNodes, isElementChecked) {
   );
 };
 
-prototype.pushMustacheInContent = function(name, args, pairs, morphNum) {
-  this.source.push(this.indent+'  hooks.content(morph' + morphNum + ', ' + name + ', context, ' + args + ', ' + hash(pairs) + ', env);\n');
+prototype.pushMustacheInContent = function(name, args, hashArgs, pairs, morphNum) {
+  this.source.push(this.indent+'  hooks.content(morph' + morphNum + ', ' + name + ', context, ' + args + ', ' + hashArgs + ', ' + hash(pairs) + ', env);\n');
 };
 
-prototype.pushMustacheInNode = function(name, args, pairs, elementNum) {
-  this.source.push(this.indent+'  hooks.element(element' + elementNum + ', ' + name + ', context, ' + args + ', ' + hash(pairs) + ', env);\n');
+prototype.pushMustacheInNode = function(name, args, hashArgs, optionPairs, elementNum) {
+  this.source.push(this.indent+'  hooks.element(element' + elementNum + ', ' + name + ', context, ' + args + ', ' + hashArgs + ', ' + hash(optionPairs) + ', env);\n');
 };
 
 prototype.shareParent = function(i) {

--- a/packages/htmlbars-compiler/tests/fragment_test.js
+++ b/packages/htmlbars-compiler/tests/fragment_test.js
@@ -79,12 +79,13 @@ test('hydrates a fragment with morph mustaches', function () {
   var env = {
     dom: new DOMHelper(),
     hooks: {
-      content: function(morph, path, context, params, options) {
+      content: function(morph, path, context, params, hash, options) {
         contentResolves.push({
           morph: morph,
           context: context,
           path: path,
           params: params,
+          hash: hash,
           options: options
         });
       }
@@ -100,8 +101,8 @@ test('hydrates a fragment with morph mustaches', function () {
   equal(foo.context, context);
   equal(foo.path, 'foo');
   deepEqual(foo.params, ["foo",3,"blah"]);
+  deepEqual(foo.hash, {ack:"syn",bar:"baz"});
   deepEqual(foo.options.types, ["string","number","id"]);
-  deepEqual(foo.options.hash, {ack:"syn",bar:"baz"});
   deepEqual(foo.options.hashTypes, {ack:"string",bar:"id"});
   equal(foo.options.escaped, true);
 

--- a/packages/htmlbars-compiler/tests/template_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/template_compiler_test.js
@@ -8,7 +8,7 @@ QUnit.module("TemplateCompiler");
 var dom = new DOMHelper();
 
 var hooks = {
-  content: function(morph, helperName, context, params, options, env) {
+  content: function(morph, helperName, context, params, hash, options, env) {
     if (helperName === 'if') {
       if (context[params[0]]) {
         options.hooks = this;

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -1,10 +1,10 @@
 import { merge } from "./utils";
 import SafeString from '../htmlbars-util/safe-string';
 
-export function content(morph, helperName, context, params, options, env) {
+export function content(morph, helperName, context, params, hash, options, env) {
   var value, helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    value = helper(params, options, env);
+    value = helper.call(context, params, hash, options, env);
   } else {
     value = this.simple(context, helperName, options);
   }
@@ -14,19 +14,19 @@ export function content(morph, helperName, context, params, options, env) {
   morph.update(value);
 }
 
-export function component(morph, tagName, context, options, env) {
+export function component(morph, tagName, context, hash, options, env) {
   var value, helper = this.lookupHelper(tagName, context, options);
   if (helper) {
-    value = helper(null, options, env);
+    value = helper.call(context, null, hash, options, env);
   } else {
-    value = this.componentFallback(morph, tagName, context, options, env);
+    value = this.componentFallback(morph, tagName, context, hash, options, env);
   }
   morph.update(value);
 }
 
-export function componentFallback(morph, tagName, context, options, env) {
+export function componentFallback(morph, tagName, context, hash, options, env) {
   var element = env.dom.createElement(tagName);
-  var hash = options.hash, hashTypes = options.hashTypes;
+  var hashTypes = options.hashTypes;
 
   for (var name in hash) {
     if (hashTypes[name] === 'id') {
@@ -39,14 +39,14 @@ export function componentFallback(morph, tagName, context, options, env) {
   return element;
 }
 
-export function element(domElement, helperName, context, params, options, env) {
+export function element(domElement, helperName, context, params, hash, options, env) {
   var helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    helper(params, options, env);
+    helper.call(context, params, hash, options, env);
   }
 }
 
-export function attribute(params, options /*, env*/) {
+export function attribute(params, hash, options /*, env*/) {
   var attrName = params[0];
   var attrValue = params[1];
 
@@ -57,12 +57,11 @@ export function attribute(params, options /*, env*/) {
   }
 }
 
-export function concat(params, options /*, env*/) {
-  var context = options.context;
+export function concat(params, hash, options /*, env*/) {
   var value = "";
   for (var i = 0, l = params.length; i < l; i++) {
     if (options.types[i] === 'id') {
-      value += this.simple(context, params[i], options);
+      value += this.simple(this, params[i], options);
     } else {
       value += params[i];
     }
@@ -70,14 +69,14 @@ export function concat(params, options /*, env*/) {
   return value;
 }
 
-export function partial(params, options, env) {
-  return env.partials[params[0]](options.context, env);
+export function partial(params, hash, options, env) {
+  return env.partials[params[0]](this, env);
 }
 
-export function subexpr(helperName, context, params, options, env) {
+export function subexpr(helperName, context, params, hash, options, env) {
   var helper = this.lookupHelper(helperName, context, options);
   if (helper) {
-    return helper(params, options, env);
+    return helper.call(context, params, hash, options, env);
   } else {
     return this.simple(context, helperName, options);
   }


### PR DESCRIPTION
- Make the default call signature be `params, hash, options, env`.
- Remove `options.hash`.
- Ensure internal helpers are bound to the context.
- Remove `options.context`.
