### PR TITLE
Remove isTop in favor of a downstream implementation.

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler.js
+++ b/packages/htmlbars-compiler/lib/compiler.js
@@ -34,9 +34,7 @@ import { TemplateCompiler } from "./compiler/template";
  */
 export function compile(string) {
   var program = compileSpec(string);
-  var template =  new Function("return " + program)();
-  template.isTop = true;
-  return template;
+  return new Function("return " + program)();
 }
 
 /*

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -81,18 +81,6 @@ QUnit.module("HTML-based compiler (output)", {
   }
 });
 
-test("Root template has a isTop property", function() {
-  expect(2);
-  env.hooks.content = function(morph, helperName, context, params, hash, options) {
-    ok(!options.render.isTop, 'child template isTop isnt present');
-  };
-
-  var template = compile("<div>{{#if}} {{/if}}</div>");
-  template({}, env);
-
-  ok(template.isTop, 'expected isTop to be present');
-});
-
 test("Simple content produces a document fragment", function() {
   var template = compile("content");
   var fragment = template({}, env);


### PR DESCRIPTION
Ember has been updated to provide its own `isTop` (other modifications were needed also) in https://github.com/emberjs/ember.js/pull/9585.

`isTop` doesn't really seem like a fundamental HTMLBars concern (is only needed to support the current implementation of the `{{outlet}}` helper).

Closes #122.
