### PR TITLE
Keep CJS and AMD output split in dist/.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -115,24 +115,29 @@ for (var packageName in packages.dependencies) {
   var libTree = mergeTrees(packageTrees[0]),
       testTree = mergeTrees(packageTrees[1]);
 
+  // ES6
+  var pickedEs6Lib = new Funnel(libTree, {
+    destDir: '/lib/'
+  });
+  trees.push(pickedEs6Lib);
+
   // AMD lib
   var transpiledAmdLib = transpileES6(libTree, { moduleName: true, type: 'amd' });
   var concatenatedAmdLib = concatFiles(transpiledAmdLib, {
     inputFiles: ['**/*.js'],
-    outputFile: '/' + packageName + '.amd.js'
+    outputFile: '/amd/' + packageName + '.amd.js'
   });
   trees.push(concatenatedAmdLib);
 
   // CJS lib
   var transpiledCjsLib = transpileES6(libTree, { type: 'cjs' });
   var pickedCjsLib = new Funnel(transpiledCjsLib, {
-    srcDir: '/',
-    destDir: '/'
+    destDir: '/cjs/'
   });
   trees.push(pickedCjsLib);
   var pickedCjsMain = new Funnel(transpiledCjsLib, {
     srcDir: packageName+'.js',
-    destDir: packageName+'.js'
+    destDir: '/cjs/' + packageName+'.js'
   });
   trees.push(pickedCjsMain);
 
@@ -166,7 +171,7 @@ for (var packageName in packages.dependencies) {
   var transpiledCjsTests = transpileES6(mergeTrees(testTrees), { type: 'cjs' });
   var movedCjsTests = new Funnel(transpiledCjsTests, {
     srcDir: packageName+'-tests/',
-    destDir: '/'+packageName+"-tests/"
+    destDir: '/cjs/'+packageName+"-tests/"
   });
   trees.push(movedCjsTests);
 }

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -96,7 +96,7 @@ Object.keys(packages.dependencies).forEach(function(packageName){
     return runBrowserTests("?packages=" + packageName);
   });
   if (packages.dependencies[packageName].node) {
-    var testDir = 'dist/'+packageName+'-tests/';
+    var testDir = 'dist/cjs/'+packageName+'-tests/';
     testRuns = testRuns.then(function(){
       console.log('----');
       return runNodeTests(testDir);

--- a/test/index.html
+++ b/test/index.html
@@ -26,7 +26,7 @@
     }
 
     function injectLib(packageName) {
-      injectScript("../" + packageName + ".amd.js");
+      injectScript("../amd/" + packageName + ".amd.js");
     }
 
     function injectTests(packageName) {


### PR DESCRIPTION
```
dist
├── amd
│   ├── htmlbars-compiler.amd.js
│   ├── htmlbars-runtime.amd.js
│   ├── htmlbars-util.amd.js
│   ├── htmlbars.amd.js
│   └── morph.amd.js
├── cjs
│   ├── htmlbars-compiler
│   ├── htmlbars-compiler-tests
│   ├── htmlbars-compiler.js
│   ├── htmlbars-runtime
│   ├── htmlbars-runtime-tests
│   ├── htmlbars-runtime.js
│   ├── htmlbars-tests
│   ├── htmlbars-util
│   ├── htmlbars-util-tests
│   ├── htmlbars-util.js
│   ├── htmlbars.js
│   ├── morph
│   ├── morph-tests
│   ├── morph.js
│   ├── simple-html-tokenizer
│   └── simple-html-tokenizer.js
├── lib
│   ├── htmlbars-compiler
│   ├── htmlbars-compiler.js
│   ├── htmlbars-runtime
│   ├── htmlbars-runtime.js
│   ├── htmlbars-util
│   ├── htmlbars-util.js
│   ├── htmlbars.js
│   ├── morph
│   ├── morph.js
│   ├── simple-html-tokenizer
│   └── simple-html-tokenizer.js
└── test
    ├── htmlbars-compiler-tests.amd.js
    ├── htmlbars-runtime-tests.amd.js
    ├── htmlbars-tests.amd.js
    ├── htmlbars-util-tests.amd.js
    ├── index.html
    ├── loader.js
    ├── morph-tests.amd.js
    ├── packages-config.js
    ├── qunit.css
    ├── qunit.js
    ├── support
    └── test-support.amd.js

20 directories, 28 files

```
