### PR TITLE
Prepare for publishing to NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "htmlbars",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "HTMLBars compiles Handlebars templates into document fragments rather than string buffers",
-  "main": "index.js",
+  "main": "dist/cjs/htmlbars.js",
   "scripts": {
     "prepublish": "bower install",
     "build": "bin/build.js",


### PR DESCRIPTION
- Ensure that `require('htmlbars')` works properly.
- Bump version.

Will publish to NPM for consumption of ES6 (for Ember) and CJS (for precompiling templates) once merged.
