### PR TITLE
Fix jshint in tests

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -133,18 +133,14 @@ for (var packageName in packages.dependencies) {
   // jsHint tests
   var jsHintLibTree = new Funnel(libTree, {
     include: [new RegExp(packageName), new RegExp(packageName + '.+\.js$')],
-    exclude: [/htmlbars-compiler\/handlebars/]
+    exclude: [/htmlbars-compiler\/handlebars/],
+    destDir: packageName+'-tests/'
   });
   jsHintLibTree = removeFile(jsHintLibTree, {
     srcFile: 'htmlbars-runtime.js' // Uses ES6 `module` syntax. Breaks jsHint
   });
   testTrees.push(jsHint(jsHintLibTree, { destFile: '/' + packageName + '-tests/jshint-lib.js' }));
-
-  var jsHintTestTree = new Funnel(testTree, {
-    srcDir: packageName+'-tests/',
-    destDir: packageName+'-tests/'
-  });
-  testTrees.push(jsHint(jsHintTestTree, { destFile: '/' + packageName + '-tests/jshint-tests.js' }));
+  testTrees.push(jsHint(testTree, { destFile: '/' + packageName + '-tests/jshint-tests.js' }));
 
   // AMD tests
   var transpiledAmdTests = transpileES6(mergeTrees(testTrees), { moduleName: true, type: 'amd' });

--- a/test/index.html
+++ b/test/index.html
@@ -92,7 +92,7 @@
 
       for (var i = 0; i < packagesToTest.length; i++) {
         if (root === packagesToTest[i] + '-tests') {
-          if (key.match(/-jshint\//) && QUnit.urlParams.nojshint) {
+          if (key.match(/\.jshint$/) && QUnit.urlParams.nojshint) {
             continue;
           }
           requireModule(key);


### PR DESCRIPTION
Jshint tests for the lib folder was being generated in `packageName` instead of `packageName+'-tests/`, which is expected for the [test loader](https://github.com/tildeio/htmlbars/blob/master/test/index.html#L94).

//cc @rwjblue 
