### PR TITLE
Remove trailing semicolon from generated template.

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -75,7 +75,7 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     hydrationProgram +
     indent+'    return fragment;\n' +
     indent+'  };\n' +
-    indent+'}());';
+    indent+'}())';
 
   this.templates.push(template);
 };


### PR DESCRIPTION
This semicolon means that we cannot include a compiled template inline
within a class definition.

Specifically the following breaks (needed in Ember) with the semi-colon:

``` javascript
export default Ember.HTMLBars.template(
 /* HTMLBars compiled template that has trailing semicolon as below*/
 ;
)
```
