### PR TITLE
Add removeAttribute to DomHelper.

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -127,6 +127,10 @@ prototype.setAttribute = function(element, name, value) {
   element.setAttribute(name, value);
 };
 
+prototype.removeAttribute = function(element, name) {
+  element.removeAttribute(name);
+};
+
 if (doc && doc.createElementNS) {
   // Only opt into namespace detection if a contextualElement
   // is passed.

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -39,6 +39,16 @@ test('#setAttribute', function(){
   equalHTML(node, '<div id="super-tag"></div>');
 });
 
+test('#removeAttribute', function(){
+  var node = dom.createElement('div');
+  dom.setAttribute(node, 'id', 'super-tag');
+  equalHTML(node, '<div id="super-tag"></div>', 'precond - attribute exists');
+
+
+  dom.removeAttribute(node, 'id');
+  equalHTML(node, '<div></div>', 'attribute was removed');
+});
+
 test('#createElement of tr with contextual table element', function(){
   var tableElement = document.createElement('table'),
       node = dom.createElement('tr', tableElement);


### PR DESCRIPTION
Needed by Ember to allow abstraction of `element.removeAttribute` (in case we end up with special logic).

Also, dovetails with `dom.setAttribute`.
