### PR TITLE
Do not cache parent node as element

### DIFF
--- a/packages/morph/lib/morph.js
+++ b/packages/morph/lib/morph.js
@@ -43,7 +43,10 @@ Morph.prototype.parent = function () {
   if (!this.element) {
     var parent = this.start.parentNode;
     if (this._parent !== parent) {
-      this.element = this._parent = parent;
+      this._parent = parent;
+    }
+    if (parent.nodeType === 1) {
+      this.element = parent;
     }
   }
   return this._parent;

--- a/packages/morph/tests/morph-test.js
+++ b/packages/morph/tests/morph-test.js
@@ -111,7 +111,8 @@ function morphTests(factory) {
   });
 
   test('update '+factory.name, function () {
-    var setup = factory.create(),
+    var div = document.createElement('div'),
+      setup = factory.create(),
       fragment = setup.fragment,
       morph = setup.morph,
       startHTML = setup.startHTML,
@@ -136,6 +137,27 @@ function morphTests(factory) {
     morph.update(duckTypedSafeString);
     html = startHTML+'<div>updated</div>'+endHTML;
     equalHTML(fragment, html);
+
+    var newFrag = document.createDocumentFragment();
+    newFrag.appendChild(fragment);
+
+    morph.update('oh hai');
+    html = startHTML+'oh hai'+endHTML;
+    equalHTML(newFrag, html);
+
+    morph.update('oh bai');
+    html = startHTML+'oh bai'+endHTML;
+    equalHTML(newFrag, html);
+
+    div.appendChild(newFrag);
+
+    morph.update('oh hai');
+    html = '<div>'+startHTML+'oh hai'+endHTML+'</div>';
+    equalHTML(div, html);
+
+    morph.update('oh bai');
+    html = '<div>'+startHTML+'oh bai'+endHTML+'</div>';
+    equalHTML(div, html);
   });
 }
 


### PR DESCRIPTION
The element property on a morph is never cleared, however the parent of a morph's start and end nodes may change if it is attached to a document fragment which is appended to DOM.

Because of this, the parent cannot be cached on a morph's element property.

Would like to add a test.
