### PR TITLE
Allow HTML comments to be used in templates.

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/fragment.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment.js
@@ -33,6 +33,11 @@ FragmentCompiler.prototype.createText = function(str) {
   this.source.push(this.indent+'  var '+el+' = dom.createTextNode('+string(str)+');\n');
 };
 
+FragmentCompiler.prototype.createComment = function(str) {
+  var el = 'el'+(++this.depth);
+  this.source.push(this.indent+'  var '+el+' = dom.createComment('+string(str)+');\n');
+};
+
 FragmentCompiler.prototype.returnNode = function() {
   var el = 'el'+this.depth;
   this.source.push(this.indent+'  return '+el+';\n');

--- a/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
@@ -24,6 +24,11 @@ FragmentOpcodeCompiler.prototype.text = function(text, childIndex, childCount, i
   if (!isSingleRoot) { this.opcode('appendChild'); }
 };
 
+FragmentOpcodeCompiler.prototype.comment = function(comment) {
+  this.opcode('createComment', [comment.chars]);
+  this.opcode('appendChild');
+};
+
 FragmentOpcodeCompiler.prototype.openElement = function(element) {
   this.opcode('createElement', [element.tag]);
   forEach(element.attributes, this.attribute, this);

--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -54,6 +54,10 @@ HydrationOpcodeCompiler.prototype.text = function(/* string, pos, len */) {
   ++this.currentDOMChildIndex;
 };
 
+HydrationOpcodeCompiler.prototype.comment = function(/* string, pos, len */) {
+  ++this.currentDOMChildIndex;
+};
+
 HydrationOpcodeCompiler.prototype.openElement = function(element, pos, len, isSingleRoot, mustacheCount, blankChildTextNodes) {
   distributeMorphs(this.morphs, this.opcodes);
   ++this.currentDOMChildIndex;

--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -130,6 +130,11 @@ TemplateCompiler.prototype.text = function(string, i, l, r) {
   this.hydrationOpcodeCompiler.text(string, i, l, r);
 };
 
+TemplateCompiler.prototype.comment = function(string, i, l, r) {
+  this.fragmentOpcodeCompiler.comment(string, i, l, r);
+  this.hydrationOpcodeCompiler.comment(string, i, l, r);
+};
+
 TemplateCompiler.prototype.mustache = function (mustache, i, l) {
   this.fragmentOpcodeCompiler.mustache(mustache, i, l);
   this.hydrationOpcodeCompiler.mustache(mustache, i, l);

--- a/packages/htmlbars-compiler/lib/compiler/template_visitor.js
+++ b/packages/htmlbars-compiler/lib/compiler/template_visitor.js
@@ -199,6 +199,12 @@ TemplateVisitor.prototype.text = function(text) {
   frame.actions.push(['text', [text, frame.childIndex, frame.childCount, isSingleRoot]]);
 };
 
+TemplateVisitor.prototype.comment = function(text) {
+  var frame = this.getCurrentFrame();
+
+  frame.actions.push(['comment', [text, frame.childIndex, frame.childCount, true]]);
+};
+
 TemplateVisitor.prototype.mustache = function(mustache) {
   var frame = this.getCurrentFrame();
   frame.mustacheCount++;

--- a/packages/htmlbars-compiler/lib/html-parser/node-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/node-handlers.js
@@ -32,6 +32,11 @@ var nodeHandlers = {
   },
 
   block: function(block) {
+    if (this.tokenizer.state === 'comment') {
+      this.tokenizer.token.addChar('{{' + this.sourceForMustache(block) + '}}');
+      return;
+    }
+
     switchToHandlebars(this);
     this.acceptToken(block);
 
@@ -57,6 +62,11 @@ var nodeHandlers = {
   },
 
   mustache: function(mustache) {
+    if (this.tokenizer.state === 'comment') {
+      this.tokenizer.token.addChar('{{' + this.sourceForMustache(mustache) + '}}');
+      return;
+    }
+
     switchToHandlebars(this);
     this.acceptToken(mustache);
   },

--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -70,7 +70,9 @@ var tokenHandlers = {
   },
 
   block: function(/*block*/) {
-    if (this.tokenizer.state !== 'data') {
+    if (this.tokenizer.state === 'comment') {
+      return;
+    } else if (this.tokenizer.state !== 'data') {
       throw new Error("A block may only be used inside an HTML element or another block.");
     }
   },

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -194,6 +194,22 @@ test("The compiler can handle comments", function() {
   compilesTo("<div>{{! Better not break! }}content</div>", '<div>content</div>', {});
 });
 
+test("The compiler can handle HTML comments", function() {
+  compilesTo('<div><!-- Just passing through --></div>');
+});
+
+test("The compiler can handle HTML comments with mustaches in them", function() {
+  compilesTo('<div><!-- {{foo}} --></div>', '<div><!-- {{foo}} --></div>', { foo: 'bar' });
+});
+
+test("The compiler can handle HTML comments with complex mustaches in them", function() {
+  compilesTo('<div><!-- {{foo bar baz}} --></div>', '<div><!-- {{foo bar baz}} --></div>', { foo: 'bar' });
+});
+
+test("The compiler can handle HTML comments with multi-line mustaches in them", function() {
+  compilesTo('<div><!-- {{#each foo as |bar|}}\n{{bar}}\n\n{{/each}} --></div>');
+});
+
 // TODO: Revisit partial syntax.
 // test("The compiler can handle partials in handlebars partial syntax", function() {
 //   registerPartial('partial_name', "<b>Partial Works!</b>");

--- a/packages/htmlbars-compiler/tests/template_visitor_test.js
+++ b/packages/htmlbars-compiler/tests/template_visitor_test.js
@@ -149,3 +149,12 @@ test("component", function() {
     ['endProgram', [0]]
   ]);
 });
+
+test("comment", function() {
+  var input = "<!-- some comment -->";
+  actionsEqual(input, [
+    ['startProgram', [0, []]],
+    ['comment', [0, 1, true]],
+    ['endProgram', [0]]
+  ]);
+});

--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -171,6 +171,10 @@ prototype.createTextNode = function(text){
   return this.document.createTextNode(text);
 };
 
+prototype.createComment = function(text){
+  return this.document.createComment(text);
+};
+
 prototype.repairClonedNode = function(element, blankChildTextNodes, isChecked){
   if (deletesBlankTextNodes && blankChildTextNodes.length > 0) {
     for (var i=0, len=blankChildTextNodes.length;i<len;i++){


### PR DESCRIPTION
Initial support was added to the parser in https://github.com/tildeio/htmlbars/pull/150, but it did not add all of the functionality needed to fully enable using comments in templates.
