### PR TITLE
Robust tracking of quoted and unquoted attributes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "htmlbars",
   "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#83952381ed525eaff9b81c79ccd2ae5af1c9ed9f"
+    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#db61573bdeac55be3eddcd166df92851c0fa7da9"
   },
   "devDependencies": {
     "loader": "stefanpenner/loader.js#7f79173fd5c61dc256af9aa01c56d50ebfec10fe",

--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -141,8 +141,12 @@ HydrationOpcodeCompiler.prototype.attribute = function(attr) {
     return;
   }
 
-  var quoted = attr.quoted;
-  var params = quoted ? attr.value : [ attr.value ];
+  var params;
+  if (attr.value.type === 'sexpr') {
+    params = [ attr.value ];
+  } else {
+    params = attr.value;
+  }
 
   this.opcode('program', null, null);
   processSexpr(this, { params: params });
@@ -151,7 +155,7 @@ HydrationOpcodeCompiler.prototype.attribute = function(attr) {
     this.opcode('element', ++this.elementNum);
     this.element = null;
   }
-  this.opcode('attribute', quoted, attr.name, params.length, this.elementNum);
+  this.opcode('attribute', attr.quoted, attr.name, params.length, this.elementNum);
 };
 
 HydrationOpcodeCompiler.prototype.nodeHelper = function(mustache) {

--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -84,14 +84,17 @@ var tokenHandlers = {
     switch(state) {
       case "beforeAttributeValue":
         this.tokenizer.state = 'attributeValueUnquoted';
+        token.markAttributeQuoted(false);
         token.addToAttributeValue(mustache.sexpr);
+        token.finalizeAttributeValue();
         return;
       case "attributeValueDoubleQuoted":
       case "attributeValueSingleQuoted":
+        token.markAttributeQuoted(true);
         token.addToAttributeValue(mustache.sexpr);
-        token.attributes[token.attributes.length - 1].quoted = true;
         return;
       case "attributeValueUnquoted":
+        token.markAttributeQuoted(false);
         token.addToAttributeValue(mustache.sexpr);
         return;
       case "beforeAttributeName":

--- a/packages/htmlbars-compiler/tests/combined_ast_node-test.js
+++ b/packages/htmlbars-compiler/tests/combined_ast_node-test.js
@@ -144,7 +144,7 @@ test("elements can have empty attributes", function() {
   var t = '<img id="">';
   astEqual(t, root([
     element("img", [
-      attr("id", text(""))
+      attr("id", text(""), true)
     ])
   ]));
 });
@@ -220,7 +220,7 @@ test("Handlebars embedded in an attribute (quoted)", function() {
   var t = 'some <div class="{{foo}}">content</div> done';
   astEqual(t, root([
     text("some "),
-    element("div", [ attr("class", [ sexpr([id('foo')]) ], true) ], [], [
+    element("div", [ attr("class", sexpr([id('foo')]), true) ], [], [
       text("content")
     ]),
     text(" done")
@@ -231,7 +231,7 @@ test("Handlebars embedded in an attribute (unquoted)", function() {
   var t = 'some <div class={{foo}}>content</div> done';
   astEqual(t, root([
     text("some "),
-    element("div", [ attr("class", sexpr([id('foo')])) ], [], [
+    element("div", [ attr("class", sexpr([id('foo')]), false) ], [], [
       text("content")
     ]),
     text(" done")
@@ -243,7 +243,7 @@ test("Handlebars embedded in an attribute (sexprs)", function() {
   astEqual(t, root([
     text("some "),
     element("div", [
-      attr("class", [ sexpr([id('foo'), sexpr([id('foo'), string('abc')])]) ], true)
+      attr("class", sexpr([id('foo'), sexpr([id('foo'), string('abc')])]), true)
     ], [], [
       text("content")
     ]),
@@ -330,7 +330,7 @@ test("Involved block helper", function() {
 test("Node helpers", function() {
   var t = "<p {{action 'boom'}} class='bar'>Some content</p>";
   astEqual(t, root([
-    element('p', [attr('class', text('bar'))], [mustache([id('action'), string('boom')])], [
+    element('p', [attr('class', text('bar'), true)], [mustache([id('action'), string('boom')])], [
       text('Some content')
     ])
   ]));
@@ -458,10 +458,10 @@ test("Components", function() {
   astEqual(t, root([
     text(''),
     component('x-foo', [
-      attr('a', text('b')),
-      attr('c', text('d')),
-      attr('e',  sexpr([id('f')])),
-      attr('id', [ sexpr([id('bar')]) ], true),
+      attr('a', text('b'), false),
+      attr('c', text('d'), true),
+      attr('e', sexpr([id('f')]), false),
+      attr('id', sexpr([id('bar')]), true),
       attr('class', [ string('foo-'), sexpr([id('bar')]) ], true)
     ], program([
       text(''),

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -117,10 +117,27 @@ test("Null quoted attribute value calls toString on the value", function() {
 });
 
 test("Null unquoted attribute value removes that attribute", function() {
+
   var template = compile('<input disabled={{isDisabled}}>');
   var fragment = template({isDisabled: null}, env);
 
   equalTokens(fragment, '<input>');
+});
+
+test("unquoted attribute string is just that", function() {
+
+  var template = compile('<input value=funstuff>');
+  var fragment = template({}, env);
+
+  equalTokens(fragment, '<input value="funstuff">');
+});
+
+test("unquoted attribute expression is string", function() {
+
+  var template = compile('<input value={{funstuff}}>');
+  var fragment = template({funstuff: "oh my"}, env);
+
+  equalTokens(fragment, '<input value="oh my">');
 });
 
 test("Simple elements can have arbitrary attributes", function() {


### PR DESCRIPTION
Requires https://github.com/tildeio/simple-html-tokenizer/pull/13

Instead of using the presence of a value as the identifier for a quoted state, track this in the tokenizer
