### PR TITLE
Refactor AST to always treat sexprs as an array

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -141,12 +141,7 @@ HydrationOpcodeCompiler.prototype.attribute = function(attr) {
     return;
   }
 
-  var params;
-  if (attr.value.type === 'sexpr') {
-    params = [ attr.value ];
-  } else {
-    params = attr.value;
-  }
+  var params = attr.value;
 
   this.opcode('program', null, null);
   processSexpr(this, { params: params });

--- a/packages/htmlbars-compiler/lib/html-parser/tokens.js
+++ b/packages/htmlbars-compiler/lib/html-parser/tokens.js
@@ -48,7 +48,9 @@ StartTag.prototype.finalizeAttributeValue = function() {
       attr.value = null;
     }
   } else if (attr.value.length === 1) {
-    attr.value = attr.value[0];
+    if (attr.value[0].type === 'text') {
+      attr.value = attr.value[0];
+    }
   } else {
     // Convert TextNode to StringNode
     for (var i = 0; i < attr.value.length; i++) {

--- a/packages/htmlbars-compiler/tests/combined_ast_node-test.js
+++ b/packages/htmlbars-compiler/tests/combined_ast_node-test.js
@@ -220,7 +220,7 @@ test("Handlebars embedded in an attribute (quoted)", function() {
   var t = 'some <div class="{{foo}}">content</div> done';
   astEqual(t, root([
     text("some "),
-    element("div", [ attr("class", sexpr([id('foo')]), true) ], [], [
+    element("div", [ attr("class", [ sexpr([id('foo')]) ], true) ], [], [
       text("content")
     ]),
     text(" done")
@@ -231,7 +231,7 @@ test("Handlebars embedded in an attribute (unquoted)", function() {
   var t = 'some <div class={{foo}}>content</div> done';
   astEqual(t, root([
     text("some "),
-    element("div", [ attr("class", sexpr([id('foo')]), false) ], [], [
+    element("div", [ attr("class", [ sexpr([id('foo')]) ], false) ], [], [
       text("content")
     ]),
     text(" done")
@@ -243,7 +243,7 @@ test("Handlebars embedded in an attribute (sexprs)", function() {
   astEqual(t, root([
     text("some "),
     element("div", [
-      attr("class", sexpr([id('foo'), sexpr([id('foo'), string('abc')])]), true)
+      attr("class", [ sexpr([id('foo'), sexpr([id('foo'), string('abc')])]) ], true)
     ], [], [
       text("content")
     ]),
@@ -330,7 +330,7 @@ test("Involved block helper", function() {
 test("Node helpers", function() {
   var t = "<p {{action 'boom'}} class='bar'>Some content</p>";
   astEqual(t, root([
-    element('p', [attr('class', text('bar'), true)], [mustache([id('action'), string('boom')])], [
+    element('p', [ attr('class', text('bar'), true) ], [mustache([id('action'), string('boom')])], [
       text('Some content')
     ])
   ]));
@@ -460,8 +460,8 @@ test("Components", function() {
     component('x-foo', [
       attr('a', text('b'), false),
       attr('c', text('d'), true),
-      attr('e', sexpr([id('f')]), false),
-      attr('id', sexpr([id('bar')]), true),
+      attr('e', [ sexpr([id('f')]) ], false),
+      attr('id', [ sexpr([id('bar')]) ], true),
       attr('class', [ string('foo-'), sexpr([id('bar')]) ], true)
     ], program([
       text(''),


### PR DESCRIPTION
`null`, `TextNode`, and an array (of sexprs) are all legal values for the attribute node `value` property. Nothing else.
