### PR TITLE
Add compiler plugins.

### DIFF
--- a/packages/htmlbars-compiler/lib/main.js
+++ b/packages/htmlbars-compiler/lib/main.js
@@ -1,2 +1,11 @@
-import {compilerSpec} from "./htmlbars-compiler/compiler";
-export {compilerSpec};
+import {
+  compile,
+  compilerSpec
+} from "./htmlbars-compiler/compiler";
+import Walker from "./htmlbars-compiler/walker";
+
+export {
+  compile,
+  compilerSpec,
+  Walker
+};

--- a/packages/htmlbars-compiler/lib/parser.js
+++ b/packages/htmlbars-compiler/lib/parser.js
@@ -7,6 +7,12 @@ export function preprocess(html, options) {
   var ast = parse(html);
   var combined = new HTMLProcessor(html, options).acceptNode(ast);
 
+  if (options && options.plugins && options.plugins.ast) {
+    for (var i = 0, l = options.plugins.ast.length; i < l; i++) {
+      combined = options.plugins.ast[i](combined);
+    }
+  }
+
   return combined;
 }
 

--- a/packages/htmlbars-compiler/lib/walker.js
+++ b/packages/htmlbars-compiler/lib/walker.js
@@ -1,0 +1,54 @@
+function Walker(order) {
+  this.order = order;
+  this.stack = [];
+}
+
+export default Walker;
+
+Walker.prototype.visit = function(node, callback) {
+  if (!node) {
+    return;
+  }
+
+  this.stack.push(node);
+
+  if (this.order === 'post') {
+    this.children(node, callback);
+    callback(node, this);
+  } else {
+    callback(node, this);
+    this.children(node, callback);
+  }
+
+  this.stack.pop();
+};
+
+var visitors = {
+  program: function(walker, node, callback) {
+    for (var i = 0; i < node.statements.length; i++) {
+      walker.visit(node.statements[i], callback);
+    }
+  },
+
+  element: function(walker, node, callback) {
+    for (var i = 0; i < node.children.length; i++) {
+      walker.visit(node.children[i], callback);
+    }
+  },
+
+  block: function(walker, node, callback) {
+    walker.visit(node.program, callback);
+    walker.visit(node.inverse, callback);
+  },
+
+  component: function(walker, node, callback) {
+    walker.visit(node.program, callback);
+  }
+};
+
+Walker.prototype.children = function(node, callback) {
+  var visitor = visitors[node.type];
+  if (visitor) {
+    visitor(this, node, callback);
+  }
+};

--- a/packages/htmlbars-compiler/tests/plugin_test.js
+++ b/packages/htmlbars-compiler/tests/plugin_test.js
@@ -1,0 +1,63 @@
+import { preprocess } from "../htmlbars-compiler/parser";
+
+QUnit.module('Compiler plugins: AST');
+
+
+test('AST plugins can be provided to the compiler', function() {
+  expect(1);
+
+  function transform() {
+    ok(true, 'transform was called!');
+  }
+
+  preprocess('<div></div>', {
+    plugins: {
+      ast: [ transform ]
+    }
+  });
+});
+
+test('AST plugins can modify the AST', function() {
+  expect(1);
+
+  var expected = "OOOPS, MESSED THAT UP!";
+
+  function transform() {
+    return expected;
+  }
+
+  var ast = preprocess('<div></div>', {
+    plugins: {
+      ast: [ transform ]
+    }
+  });
+
+  equal(ast, expected, 'return value from AST transform is used');
+});
+
+test('AST plugins can be chained', function() {
+  expect(2);
+
+  var expected = "OOOPS, MESSED THAT UP!";
+
+  function transform() {
+    return expected;
+  }
+
+  function secondaryTransform(ast) {
+    equal(ast, expected, 'return value from AST transform is used');
+
+    return 'BOOM!';
+  }
+
+  var ast = preprocess('<div></div>', {
+    plugins: {
+      ast: [ 
+        transform,
+        secondaryTransform
+      ]
+    }
+  });
+
+  equal(ast, 'BOOM!', 'return value from last AST transform is used');
+});

--- a/packages/htmlbars-compiler/tests/walker_test.js
+++ b/packages/htmlbars-compiler/tests/walker_test.js
@@ -1,0 +1,46 @@
+import { preprocess } from '../htmlbars-compiler/parser';
+import Walker from '../htmlbars-compiler/walker';
+
+function compareWalkedNodes(html, expected) {
+  var ast = preprocess(html);
+  var walker = new Walker();
+  var nodes = [];
+
+  walker.visit(ast, function(node) {
+    nodes.push(node.type);
+  });
+
+  deepEqual(nodes, expected);
+}
+
+QUnit.module('AST Walker');
+
+test('walks elements', function() {
+  compareWalkedNodes('<div><li></li></div>', [
+    'program',
+    'element',
+    'element'
+  ]);
+});
+
+test('walks blocks', function() {
+  compareWalkedNodes('{{#foo}}<li></li>{{/foo}}', [
+    'program',
+    'text',
+    'block',
+    'program',
+    'element',
+    'text'
+  ]);
+});
+
+test('walks components', function() {
+  compareWalkedNodes('<my-foo><li></li></my-foo>', [
+    'program',
+    'text',
+    'component',
+    'program',
+    'element',
+    'text'
+  ]);
+});

--- a/packages/htmlbars/lib/main.js
+++ b/packages/htmlbars/lib/main.js
@@ -6,8 +6,12 @@
  * @version   VERSION_STRING_PLACEHOLDER
  */
 
-import {compile, compileSpec} from "./htmlbars-compiler/compiler";
+import {
+  compile,
+  compileSpec
+} from "./htmlbars-compiler/compiler";
+import Walker from "./htmlbars-compiler/walker";
 import Morph from "./morph/morph";
 import DOMHelper from "./morph/dom-helper";
 
-export {compile, compileSpec, Morph, DOMHelper};
+export {compile, compileSpec, Morph, DOMHelper, Walker};


### PR DESCRIPTION
AST plugins allow consumers to preprocess and manipulate the AST. This allows more efficiency in final compiled output and helps downstream consumers use much more idiomatic helper code but provide a human readable usage.

For example:

``` javascript
{{#each foo in bar}}
{{/each}}
```

Can be preprocessed and transformed into:

``` javascript
{{#each bar keyword="foo"}}
{{/each}}
```

---

Credit to @mmun for most of this code, any mistakes are my own.
