### PR TITLE
Failing test for omitted closing tags.

### DIFF
--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -966,6 +966,20 @@ test("Block params - Helper should know how many block params it was called with
   compile('{{#with-block-params as |x y z|}}{{/with-block-params}}')({ count: 3 }, env, document.body);
 });
 
+test("Closing tags are not required for <li> elements", function() {
+  var template = compile("<ul><li>Something<li>Something Else</ul>");
+  var fragment = template({}, env);
+
+  equalTokens(fragment, '<ul><li>Something<li>Something Else</ul>');
+});
+
+test("Closing tags are not required for <p> elements", function() {
+  var template = compile("<div><p>Something</div>");
+  var fragment = template({}, env);
+
+  equalTokens(fragment, '<div><p>Something</div>');
+});
+
 if (document.createElement('div').namespaceURI) {
 
 QUnit.module("HTML-based compiler (output, svg)", {


### PR DESCRIPTION
Some elements do not need a closing tag. Both `<p>` and `<li>` fall into
this category.
- https://html.spec.whatwg.org/multipage/semantics.html#the-p-element
- https://html.spec.whatwg.org/multipage/semantics.html#the-li-element

```
Error: Closing tag ul did not match last open tag li
    at HTMLProcessor.tokenHandlers.EndTag (http://localhost:6200/amd/htmlbars-compiler.amd.js:2766:17)
    at HTMLProcessor.acceptToken (http://localhost:6200/amd/htmlbars-compiler.amd.js:2903:47)

Error: Closing tag div did not match last open tag p
    at HTMLProcessor.tokenHandlers.EndTag (http://localhost:6200/amd/htmlbars-compiler.amd.js:2766:17)
    at HTMLProcessor.acceptToken (http://localhost:6200/amd/htmlbars-compiler.amd.js:2903:47)
```
