### PR TITLE
Cleanup hooks

### DIFF
--- a/demos/compile-and-run.html
+++ b/demos/compile-and-run.html
@@ -30,10 +30,18 @@
           compileSpec = compiler.compileSpec,
           DOMHelper   = requireModule('morph').DOMHelper,
           hooks       = requireModule('htmlbars-runtime').hooks;
+          helpers     = requireModule('htmlbars-runtime').helpers;
+
+      var templateSource = localStorage.getItem('templateSource');
+      if (templateSource) {
+        textarea.value = templateSource;
+      }
 
       button.addEventListener('click', function(){
         var source = textarea.value,
           data = {}, compileOptions = {} ;
+
+        localStorage.setItem('templateSource', source);
 
         try {
           data = JSON.parse(dataarea.value);
@@ -45,7 +53,8 @@
         try {
           var templateSpec = compileSpec(source, compileOptions),
               template     = compile(source, compileOptions),
-              dom          = template(data, {hooks: hooks, dom: new DOMHelper()}, output);
+              env          = { dom: new DOMHelper(), hooks: hooks, helpers: helpers };
+              dom          = template(data, env, output);
           output.innerHTML = '<pre><code>'+JSON.stringify(data)+'</code></pre><hr><pre><code>'+templateSpec+'</code></pre><hr>';
           output.appendChild(dom);
         } catch(e) {

--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -40,6 +40,12 @@ HydrationOpcodeCompiler.prototype.startProgram = function(program, c, blankChild
   this.currentDOMChildIndex = -1;
   this.morphNum = 0;
 
+  var blockParams = program.blockParams || [];
+
+  for (var i = 0; i < blockParams.length; i++) {
+    this.opcode('blockParam', blockParams[i], i);
+  }
+
   if (blankChildTextNodes.length > 0){
     this.opcode( 'repairClonedNode',
                  blankChildTextNodes );
@@ -95,9 +101,8 @@ HydrationOpcodeCompiler.prototype.closeElement = function(element, pos, len, isS
 
 HydrationOpcodeCompiler.prototype.block = function(block, childIndex, childrenLength) {
   var sexpr = block.sexpr;
-  var program = block.program;
-
-  var blockParamsLength = program && program.blockParams ? program.blockParams.length : 0;
+  var program = block.program || {};
+  var blockParams = program.blockParams || [];
 
   var currentDOMChildIndex = this.currentDOMChildIndex;
   var start = (currentDOMChildIndex < 0) ? null : currentDOMChildIndex;
@@ -108,7 +113,7 @@ HydrationOpcodeCompiler.prototype.block = function(block, childIndex, childrenLe
 
   this.opcode('program', this.templateId++, block.inverse === null ? null : this.templateId++);
   processSexpr(this, sexpr);
-  this.opcode('helper', sexpr.params.length, morphNum, blockParamsLength);
+  this.opcode('helper', sexpr.params.length, morphNum, blockParams.length);
 };
 
 HydrationOpcodeCompiler.prototype.component = function(component, childIndex, childrenLength) {

--- a/packages/htmlbars-compiler/tests/fragment_test.js
+++ b/packages/htmlbars-compiler/tests/fragment_test.js
@@ -28,6 +28,12 @@ function hydratorFor(ast) {
   var opcodes = hydrate.compile(ast);
   var hydrate2 = new HydrationCompiler();
   var program = hydrate2.compile(opcodes, []);
+
+  var hookVars = [];
+  for (var hook in hydrate2.hooks) {
+    hookVars.push(hook + ' = hooks.' + hook);
+  }
+  program =  'var ' + hookVars.join(', ') + ';\n' + program;
   return new Function("fragment", "context", "dom", "hooks", "env", "contextualElement", program);
 }
 

--- a/packages/htmlbars-compiler/tests/html_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/html_compiler_test.js
@@ -1,7 +1,9 @@
 import { compile } from "../htmlbars-compiler/compiler";
 import { forEach } from "../htmlbars-compiler/utils";
 import { tokenize } from "../simple-html-tokenizer";
-import { hydrationHooks } from "../htmlbars-runtime/hooks";
+import defaultHooks from "../htmlbars-runtime/hooks";
+import defaultHelpers from "../htmlbars-runtime/helpers";
+import { merge } from "../htmlbars-runtime/utils";
 import { DOMHelper } from "../morph";
 import { normalizeInnerHTML } from "../htmlbars-test-helpers";
 
@@ -16,18 +18,6 @@ function registerHelper(name, callback) {
 
 function registerPartial(name, html) {
   partials[name] = compile(html);
-}
-
-function lookupHelper(helperName) {
-  if (helperName === 'attribute') {
-    return this.attribute;
-  } else if (helperName === 'concat') {
-    return this.concat;
-  } else if (helperName === 'partial') {
-    return this.partial;
-  } else {
-    return helpers[helperName];
-  }
 }
 
 function compilesTo(html, expected, context) {
@@ -68,14 +58,14 @@ function equalTokens(fragment, html) {
 
 QUnit.module("HTML-based compiler (output)", {
   setup: function() {
-    helpers = {};
+    hooks = merge({}, defaultHooks);
+    helpers = merge({}, defaultHelpers);
     partials = {};
-    hooks = hydrationHooks({lookupHelper : lookupHelper});
 
     env = {
+      dom: new DOMHelper(),
       hooks: hooks,
       helpers: helpers,
-      dom: new DOMHelper(),
       partials: partials
     };
   }
@@ -253,12 +243,8 @@ test("The compiler can handle top-level unescaped HTML", function() {
 
 test("The compiler can handle top-level unescaped tr", function() {
   var template = compile('{{{html}}}');
-  var fragment = template({
-                   html: '<tr><td>Yo</td></tr>'
-                 }, {
-                   hooks: hooks,
-                   dom: new DOMHelper()
-                 }, document.createElement('table'));
+  var context = { html: '<tr><td>Yo</td></tr>' };
+  var fragment = template(context, env, document.createElement('table'));
 
   equal(
     fragment.childNodes[1].tagName, 'TR',
@@ -267,12 +253,8 @@ test("The compiler can handle top-level unescaped tr", function() {
 
 test("The compiler can handle top-level unescaped td inside tr contextualElement", function() {
   var template = compile('{{{html}}}');
-  var fragment = template({
-                   html: '<td>Yo</td>'
-                 }, {
-                   hooks: hooks,
-                   dom: new DOMHelper()
-                 }, document.createElement('tr'));
+  var context = { html: '<td>Yo</td>' };
+  var fragment = template(context, env, document.createElement('tr'));
 
   equal(
     fragment.childNodes[1].tagName, 'TD',
@@ -280,21 +262,13 @@ test("The compiler can handle top-level unescaped td inside tr contextualElement
 });
 
 test("The compiler can handle unescaped tr in top of content", function() {
-  var helper = function(params, hash, options, env) {
+  registerHelper('test', function(params, hash, options, env) {
     return options.render(this, env, options.morph.contextualElement);
-  };
-  hooks.lookupHelper = function(name){
-    if (name === 'test') {
-      return helper;
-    }
-  };
+  });
+
   var template = compile('{{#test}}{{{html}}}{{/test}}');
-  var fragment = template({
-                   html: '<tr><td>Yo</td></tr>'
-                 }, {
-                   hooks: hooks,
-                   dom: new DOMHelper()
-                 }, document.createElement('table'));
+  var context = { html: '<tr><td>Yo</td></tr>' };
+  var fragment = template(context, env, document.createElement('table'));
 
   equal(
     fragment.childNodes[2].tagName, 'TR',
@@ -302,21 +276,13 @@ test("The compiler can handle unescaped tr in top of content", function() {
 });
 
 test("The compiler can handle unescaped tr inside fragment table", function() {
-  var helper = function(params, hash, options, env) {
+  registerHelper('test', function(params, hash, options, env) {
     return options.render(this, env, options.morph.contextualElement);
-  };
-  hooks.lookupHelper = function(name){
-    if (name === 'test') {
-      return helper;
-    }
-  };
-  var template = compile('<table>{{#test}}{{{html}}}{{/test}}</table>'),
-      fragment = template({
-                   html: '<tr><td>Yo</td></tr>'
-                 }, {
-                   hooks: hooks,
-                   dom: new DOMHelper()
-                 }, document.createElement('div'));
+  });
+
+  var template = compile('<table>{{#test}}{{{html}}}{{/test}}</table>');
+  var context = { html: '<tr><td>Yo</td></tr>' };
+  var fragment = template(context, env, document.createElement('div'));
 
   equal(
     fragment.childNodes[1].tagName, 'TR',
@@ -385,20 +351,6 @@ test("The compiler passes along the paramTypes of the hash arguments", function(
   compilesTo('<div>{{testing first=1}}</div>', '<div>number-1</div>');
   compilesTo('<div>{{testing first=true}}</div>', '<div>boolean-true</div>');
   compilesTo('<div>{{testing first=false}}</div>', '<div>boolean-false</div>');
-});
-
-test("It is possible to override the resolution mechanism", function() {
-  hooks.simple = function(context, name) {
-    if (name === 'zomg') {
-      return context.zomg;
-    } else {
-      return name.replace('.', '-');
-    }
-  };
-
-  compilesTo('<div>{{foo}}</div>', '<div>foo</div>');
-  compilesTo('<div>{{foo.bar}}</div>', '<div>foo-bar</div>');
-  compilesTo('<div>{{zomg}}</div>', '<div>hello</div>', { zomg: 'hello' });
 });
 
 test("Simple data binding using text nodes", function() {
@@ -946,7 +898,6 @@ test("Block params", function() {
     // return "C(" + options.render() + ")";
   });
   var t = '{{#a as |w x|}}{{w}},{{x}} {{#b as |x y|}}{{x}},{{y}}{{/b}} {{w}},{{x}} {{#c as |z|}}{{x}},{{z}}{{/c}}{{/a}}';
-
   compilesTo(t, 'A(W,X1 B(X2,Y) W,X1 C(X1,Z))', {});
 });
 
@@ -970,14 +921,14 @@ if (document.createElement('div').namespaceURI) {
 
 QUnit.module("HTML-based compiler (output, svg)", {
   setup: function() {
-    helpers = {};
+    hooks = merge({}, defaultHooks);
+    helpers = merge({}, defaultHelpers);
     partials = {};
-    hooks = hydrationHooks({lookupHelper : lookupHelper});
 
     env = {
+      dom: new DOMHelper(),
       hooks: hooks,
       helpers: helpers,
-      dom: new DOMHelper(),
       partials: partials
     };
   }

--- a/packages/htmlbars-runtime/lib/helpers.js
+++ b/packages/htmlbars-runtime/lib/helpers.js
@@ -1,0 +1,22 @@
+import { get } from "./utils";
+
+export function concat(params, hash, options /*, env*/) {
+  var value = "";
+  for (var i = 0, l = params.length; i < l; i++) {
+    if (options.paramTypes[i] === 'id') {
+      value += get(this, params[i], options);
+    } else {
+      value += params[i];
+    }
+  }
+  return value;
+}
+
+export function partial(params, hash, options, env) {
+  return env.partials[params[0]](this, env, options.morph.contextualElement);
+}
+
+export default {
+  concat: concat,
+  partial: partial
+};

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -1,46 +1,18 @@
-import { merge } from "./utils";
+import { get } from "./utils";
+import { concat } from "./helpers";
 
 export function content(morph, helperName, context, params, hash, options, env) {
-  var value, helper = this.lookupHelper(helperName, context, options);
+  var value, helper = lookupHelper(context, helperName, env);
   if (helper) {
     value = helper.call(context, params, hash, options, env);
   } else {
-    if (options.type === 'value') {
-      value = helperName;
-    } else {
-      value = this.simple(context, helperName, options);
-    }
+    value = get(context, helperName, options);
   }
   morph.update(value);
-}
-
-export function component(morph, tagName, context, hash, options, env) {
-  var value, helper = this.lookupHelper(tagName, context, options);
-  if (helper) {
-    value = helper.call(context, null, hash, options, env);
-  } else {
-    value = this.componentFallback(morph, tagName, context, hash, options, env);
-  }
-  morph.update(value);
-}
-
-export function componentFallback(morph, tagName, context, hash, options, env) {
-  var element = env.dom.createElement(tagName);
-  var hashTypes = options.hashTypes;
-
-  for (var name in hash) {
-    if (hashTypes[name] === 'id') {
-      element.setAttribute(name, this.simple(context, hash[name], options));
-    } else {
-      element.setAttribute(name, hash[name]);
-    }
-  }
-  element.appendChild(options.render(context, env, morph.contextualElement));
-  return element;
 }
 
 export function element(domElement, helperName, context, params, hash, options, env) {
-  var helper = this.lookupHelper(helperName, context, options);
+  var helper = lookupHelper(context, helperName, env);
   if (helper) {
     helper.call(context, params, hash, options, env);
   }
@@ -62,65 +34,53 @@ export function attribute(domElement, attributeName, quoted, context, parts, opt
   }
 }
 
-export function concat(params, hash, options /*, env*/) {
-  var value = "";
-  for (var i = 0, l = params.length; i < l; i++) {
-    if (options.paramTypes[i] === 'id') {
-      value += this.simple(this, params[i], options);
-    } else {
-      value += params[i];
-    }
-  }
-  return value;
-}
-
-export function partial(params, hash, options, env) {
-  return env.partials[params[0]](this, env);
-}
-
 export function subexpr(helperName, context, params, hash, options, env) {
-  var helper = this.lookupHelper(helperName, context, options);
+  var helper = lookupHelper(context, helperName, env);
   if (helper) {
     return helper.call(context, params, hash, options, env);
   } else {
-    return this.simple(context, helperName, options);
+    return get(context, helperName, options);
   }
-}
-
-export function lookupHelper(helperName /*, context, options*/) {
-  if (helperName === 'attribute') {
-    return this.attribute;
-  }
-  else if (helperName === 'partial'){
-    return this.partial;
-  }
-  else if (helperName === 'concat') {
-    return this.concat;
-  }
-}
-
-export function simple(context, name /*, options*/) {
-  return context[name];
 }
 
 export function set(context, name, value) {
   context[name] = value;
 }
 
-export function hydrationHooks(extensions) {
-  var base = {
-    content: content,
-    component: component,
-    componentFallback: componentFallback,
-    element: element,
-    attribute: attribute,
-    concat: concat,
-    subexpr: subexpr,
-    lookupHelper: lookupHelper,
-    simple: simple,
-    partial: partial,
-    set: set
-  };
-
-  return extensions ? merge(extensions, base) : base;
+export function component(morph, tagName, context, hash, options, env) {
+  var value, helper = lookupHelper(context, tagName, env);
+  if (helper) {
+    value = helper.call(context, null, hash, options, env);
+  } else {
+    value = componentFallback(morph, tagName, context, hash, options, env);
+  }
+  morph.update(value);
 }
+
+function componentFallback(morph, tagName, context, hash, options, env) {
+  var element = env.dom.createElement(tagName);
+  var hashTypes = options.hashTypes;
+
+  for (var name in hash) {
+    if (hashTypes[name] === 'id') {
+      element.setAttribute(name, get(context, hash[name], options));
+    } else {
+      element.setAttribute(name, hash[name]);
+    }
+  }
+  element.appendChild(options.render(context, env, morph.contextualElement));
+  return element;
+}
+
+function lookupHelper(context, helperName, env) {
+  return env.helpers[helperName];
+}
+
+export default {
+  content: content,
+  component: component,
+  element: element,
+  attribute: attribute,
+  subexpr: subexpr,
+  set: set
+};

--- a/packages/htmlbars-runtime/lib/main.js
+++ b/packages/htmlbars-runtime/lib/main.js
@@ -1,3 +1,7 @@
-module hooks from 'htmlbars-runtime/hooks';
+import hooks from 'htmlbars-runtime/hooks';
+import helpers from 'htmlbars-runtime/hooks';
 
-export {hooks};
+export {
+  hooks,
+  helpers
+};

--- a/packages/htmlbars-runtime/lib/utils.js
+++ b/packages/htmlbars-runtime/lib/utils.js
@@ -1,3 +1,7 @@
+export function get(context, name) {
+  return context[name];
+}
+
 export function merge(options, defaults) {
   for (var prop in defaults) {
     if (options.hasOwnProperty(prop)) { continue; }

--- a/packages/htmlbars-runtime/tests/main-test.js
+++ b/packages/htmlbars-runtime/tests/main-test.js
@@ -1,10 +1,10 @@
-import {hooks} from "../htmlbars-runtime";
+import { hooks } from "../htmlbars-runtime";
 
 QUnit.module("htmlbars-runtime");
 
 function keys(obj) {
   var ownKeys = [];
-  for(var key in obj) {
+  for (var key in obj) {
     if (obj.hasOwnProperty(key)) {
       ownKeys.push(key);
     }
@@ -16,19 +16,14 @@ test("hooks are present", function () {
   var hookNames = [
     "content",
     "component",
-    "componentFallback",
     "element",
     "attribute",
-    "concat",
-    "partial",
     "subexpr",
-    "lookupHelper",
-    "simple",
-    "hydrationHooks",
     "set"
   ];
-  for (var i=0;i<hookNames.length;i++) {
-    ok(hooks[hookNames[i]], "hook "+hookNames[i]+" is present");
+
+  for (var i = 0; i < hookNames.length; i++) {
+    ok(hooks[hookNames[i]], "hook " + hookNames[i] + " is present");
   }
 
   equal(keys(hooks).length, hookNames.length, "Hooks length match");


### PR DESCRIPTION
Minor template tweaks. Nothing breaking. Reorganizes htmlbars-runtime & tests as well.

``` hbs
{{#each items as |item index|}}
  Hello {{item.name}}
{{/each}}
```

now generates

``` js
(function() {
  var child0 = (function() {
    function build(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("  Hello ");
      dom.appendChild(el0, el1);
      var el1 = dom.createTextNode("\n");
      dom.appendChild(el0, el1);
      return el0;
    }
    var cachedFragment;
    return function template(context, env, contextualElement, blockArguments) {
      var dom = env.dom;
      var hooks = env.hooks, set = hooks.set, content = hooks.content;
      dom.detectNamespace(contextualElement);
      if (cachedFragment === undefined) {
        cachedFragment = build(dom);
      }
      var fragment = dom.cloneNode(cachedFragment, true);
      var morph0 = dom.createMorphAt(fragment,0,1,contextualElement);
      set(context, "item", blockArguments[0]);
      set(context, "index", blockArguments[1]);
      content(morph0, "item.name", context, [], {}, {morph:morph0}, env);
      return fragment;
    };
  }())
  function build(dom) {
    var el0 = dom.createDocumentFragment();
    var el1 = dom.createTextNode("");
    dom.appendChild(el0, el1);
    var el1 = dom.createTextNode("");
    dom.appendChild(el0, el1);
    return el0;
  }
  var cachedFragment;
  return function template(context, env, contextualElement) {
    var dom = env.dom;
    var hooks = env.hooks, content = hooks.content;
    dom.detectNamespace(contextualElement);
    if (cachedFragment === undefined) {
      cachedFragment = build(dom);
    }
    var fragment = dom.cloneNode(cachedFragment, true);
    dom.repairClonedNode(fragment,[0,1]);
    var morph0 = dom.createMorphAt(fragment,0,1,contextualElement);
    content(morph0, "each", context, ["items"], {}, {paramTypes:["id"],hashTypes:{},render:child0,morph:morph0,blockParams:2}, env);
    return fragment;
  };
}())
```
