### PR TITLE
Rewrite templates as objects

### DIFF
--- a/demos/compile-and-run.html
+++ b/demos/compile-and-run.html
@@ -54,7 +54,7 @@
           var templateSpec = compileSpec(source, compileOptions),
               template     = compile(source, compileOptions),
               env          = { dom: new DOMHelper(), hooks: hooks, helpers: helpers };
-              dom          = template(data, env, output);
+              dom          = template.render(data, env, output);
           output.innerHTML = '<pre><code>'+JSON.stringify(data)+'</code></pre><hr><pre><code>'+templateSpec+'</code></pre><hr>';
           output.appendChild(dom);
         } catch(e) {

--- a/packages/htmlbars-compiler/lib/compiler/fragment.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment.js
@@ -11,9 +11,9 @@ FragmentCompiler.prototype.compile = function(opcodes, options) {
   this.depth = -1;
   this.indent = (options && options.indent) || "";
 
-  this.source.push(this.indent+'function build(dom) {\n');
+  this.source.push('function build(dom) {\n');
   processOpcodes(this, opcodes);
-  this.source.push(this.indent+'}\n');
+  this.source.push(this.indent+'}');
 
   return this.source.join('');
 };

--- a/packages/htmlbars-compiler/lib/compiler/helpers.js
+++ b/packages/htmlbars-compiler/lib/compiler/helpers.js
@@ -30,7 +30,7 @@ export function prepareHelper(stack, size) {
   var options = [];
 
   if (programId !== null) {
-    options.push('render:child' + programId);
+    options.push('template:child' + programId);
   }
 
   if (inverseId !== null) {

--- a/packages/htmlbars-compiler/lib/compiler/template.js
+++ b/packages/htmlbars-compiler/lib/compiler/template.js
@@ -39,7 +39,7 @@ TemplateCompiler.prototype.getChildTemplateVars = function(indent) {
   var vars = '';
   if (this.childTemplates) {
     for (var i = 0; i < this.childTemplates.length; i++) {
-      vars += indent + 'var child' + i + ' = ' + this.childTemplates[i] + '\n';
+      vars += indent + 'var child' + i + ' = ' + this.childTemplates[i] + ';\n';
     }
   }
   return vars;
@@ -64,7 +64,7 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
 
   var indent = repeat("  ", programDepth);
   var options = {
-    indent: indent + "  "
+    indent: indent + "    "
   };
 
   // function build(dom) { return fragment; }
@@ -89,18 +89,21 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
   var template =
     '(function() {\n' +
     this.getChildTemplateVars(indent + '  ') +
-    fragmentProgram +
-    indent+'  var cachedFragment;\n' +
-    indent+'  return function template(' + templateSignature + ') {\n' +
-    indent+'    var dom = env.dom;\n' +
-    this.getHydrationHooks(indent + '    ', this.hydrationCompiler.hooks) +
-    indent+'    dom.detectNamespace(contextualElement);\n' +
-    indent+'    if (cachedFragment === undefined) {\n' +
-    indent+'      cachedFragment = build(dom);\n' +
-    indent+'    }\n' +
-    indent+'    var fragment = dom.cloneNode(cachedFragment, true);\n' +
+    indent+'  return {\n' +
+    indent+'    isHTMLBars: true,\n' +
+    indent+'    cachedFragment: null,\n' +
+    indent+'    build: ' + fragmentProgram + ',\n' +
+    indent+'    render: function render(' + templateSignature + ') {\n' +
+    indent+'      var dom = env.dom;\n' +
+    this.getHydrationHooks(indent + '      ', this.hydrationCompiler.hooks) +
+    indent+'      dom.detectNamespace(contextualElement);\n' +
+    indent+'      if (this.cachedFragment === null) {\n' +
+    indent+'        this.cachedFragment = this.build(dom);\n' +
+    indent+'      }\n' +
+    indent+'      var fragment = dom.cloneNode(this.cachedFragment, true);\n' +
     hydrationProgram +
-    indent+'    return fragment;\n' +
+    indent+'      return fragment;\n' +
+    indent+'    }\n' +
     indent+'  };\n' +
     indent+'}())';
 

--- a/packages/htmlbars-compiler/tests/template_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/template_compiler_test.js
@@ -29,7 +29,7 @@ test("it works", function testFunction() {
 
   env.helpers['if'] = function(params, hash, options) {
     if (params[0]) {
-      return options.render(context, env, options.morph.contextualElement);
+      return options.template.render(context, env, options.morph.contextualElement);
     }
   };
 
@@ -38,7 +38,7 @@ test("it works", function testFunction() {
     firstName: 'Kris',
     lastName: 'Selden'
   };
-  var frag = template(context, env, document.body);
+  var frag = template.render(context, env, document.body);
   equalHTML(frag, '<div>Hello Kris Selden!</div>');
 });
 

--- a/packages/htmlbars-runtime/lib/helpers.js
+++ b/packages/htmlbars-runtime/lib/helpers.js
@@ -8,7 +8,7 @@ export function concat(params) {
 
 export function partial(params, hash, options, env) {
   var template = env.partials[params[0]];
-  return template(this, env, options.morph.contextualElement);
+  return template.render(this, env, options.morph.contextualElement);
 }
 
 export default {

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -78,7 +78,7 @@ function componentFallback(morph, tagName, context, hash, options, env) {
   for (var name in hash) {
     element.setAttribute(name, hash[name]);
   }
-  element.appendChild(options.render(context, env, morph.contextualElement));
+  element.appendChild(options.template.render(context, env, morph.contextualElement));
   return element;
 }
 


### PR DESCRIPTION
What's in your hand? Back at me. The templates are now objects.
- options.render is now options.template.
- templates must be called via `template.render(...)` instead of `template(...)`.

Example:

``` hbs
{{#each items as |item|}}
  {{item.id}}: {{item.name}}
{{/each}}
```

now compiles to

``` js
(function() {
  var child0 = (function() {
    return {
      isHTMLBars: true,
      cachedFragment: null,
      build: function build(dom) {
        var el0 = dom.createDocumentFragment();
        var el1 = dom.createTextNode("  ");
        dom.appendChild(el0, el1);
        var el1 = dom.createTextNode(": ");
        dom.appendChild(el0, el1);
        var el1 = dom.createTextNode("\n");
        dom.appendChild(el0, el1);
        return el0;
      },
      render: function render(context, env, contextualElement, blockArguments) {
        var dom = env.dom;
        var hooks = env.hooks, set = hooks.set, content = hooks.content;
        dom.detectNamespace(contextualElement);
        if (this.cachedFragment === null) {
          this.cachedFragment = this.build(dom);
        }
        var fragment = dom.cloneNode(this.cachedFragment, true);
        var morph0 = dom.createMorphAt(fragment,0,1,contextualElement);
        var morph1 = dom.createMorphAt(fragment,1,2,contextualElement);
        set(context, "item", blockArguments[0]);
        content(morph0, "item.id", context, [], {}, {morph:morph0}, env);
        content(morph1, "item.name", context, [], {}, {morph:morph1}, env);
        return fragment;
      }
    };
  }());
  return {
    isHTMLBars: true,
    cachedFragment: null,
    build: function build(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("");
      dom.appendChild(el0, el1);
      var el1 = dom.createTextNode("");
      dom.appendChild(el0, el1);
      return el0;
    },
    render: function render(context, env, contextualElement) {
      var dom = env.dom;
      var hooks = env.hooks, get = hooks.get, content = hooks.content;
      dom.detectNamespace(contextualElement);
      if (this.cachedFragment === null) {
        this.cachedFragment = this.build(dom);
      }
      var fragment = dom.cloneNode(this.cachedFragment, true);
      dom.repairClonedNode(fragment,[0,1]);
      var morph0 = dom.createMorphAt(fragment,0,1,contextualElement);
      content(morph0, "each", context, [get(context, "items", env)], {}, {template:child0,morph:morph0,blockParams:1}, env);
      return fragment;
    }
  };
}())
```
