### PR TITLE
Add support for block params for custom HTML tag syntax for components

### DIFF
--- a/packages/htmlbars-compiler/lib/compiler/hydration.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration.js
@@ -90,9 +90,12 @@ prototype.helper = function(size, morphNum, blockParamsLength) {
   this.pushMustacheInContent(prepared.name, prepared.params, prepared.hash, prepared.options, morphNum);
 };
 
-prototype.component = function(morphNum) {
+prototype.component = function(morphNum, blockParamsLength) {
   var prepared = prepareHelper(this.stack, 0);
   prepared.options.push('morph:morph'+morphNum);
+  if (blockParamsLength) {
+    prepared.options.push('blockParams:'+blockParamsLength);
+  }
   this.pushComponent(prepared.name, prepared.hash, prepared.options, morphNum);
 };
 

--- a/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration_opcode.js
@@ -121,6 +121,8 @@ HydrationOpcodeCompiler.prototype.block = function(block, childIndex, childrenLe
 
 HydrationOpcodeCompiler.prototype.component = function(component, childIndex, childrenLength) {
   var currentDOMChildIndex = this.currentDOMChildIndex;
+  var program = component.program || {};
+  var blockParams = program.blockParams || [];
 
   var start = (currentDOMChildIndex < 0 ? null : currentDOMChildIndex),
       end = (childIndex === childrenLength - 1 ? null : currentDOMChildIndex + 1);
@@ -136,7 +138,7 @@ HydrationOpcodeCompiler.prototype.component = function(component, childIndex, ch
   this.opcode('program', this.templateId++, null);
   processName(this, id);
   processHash(this, buildHashFromAttributes(component.attributes));
-  this.opcode('component', morphNum);
+  this.opcode('component', morphNum, blockParams.length);
 };
 
 HydrationOpcodeCompiler.prototype.opcode = function(type) {

--- a/packages/htmlbars-compiler/lib/html-parser/helpers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/helpers.js
@@ -32,6 +32,40 @@ export function buildHashFromAttributes(attributes) {
   return buildHash(pairs);
 }
 
+// Checks the component's attributes to see if it uses block params.
+// If it does, registers the block params with the program and
+// removes the corresponding attributes from the element.
+
+export function parseComponentBlockParams(element, program) {
+  var l = element.attributes.length;
+  var attrNames = [];
+
+  for (var i = 0; i < l; i++) {
+    attrNames.push(element.attributes[i].name);
+  }
+
+  var asIndex = attrNames.indexOf('as');
+
+  if (asIndex !== -1 && l > asIndex && attrNames[asIndex + 1].charAt(0) === '|') {
+    // Some basic validation, since we're doing the parsing ourselves
+    var paramsString = attrNames.slice(asIndex).join(' ');
+    if (paramsString.charAt(paramsString.length - 1) !== '|' || paramsString.match(/\|/g).length !== 2) {
+      throw new Error('Invalid block parameters syntax: \'' + paramsString + '\'');
+    }
+
+    var params = [];
+    for (i = asIndex + 1; i < l; i++) {
+      var param = attrNames[i].replace('|', '');
+      if (param !== '') {
+        params.push(param);
+      }
+    }
+
+    element.attributes = element.attributes.slice(0, asIndex);
+    program.blockParams = params;
+  }
+}
+
 // Adds an empty text node at the beginning and end of a program.
 // The empty text nodes *between* nodes are handled elsewhere.
 // Also processes all whitespace stripping directives.

--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -1,6 +1,6 @@
 import { buildProgram, buildComponent, buildElement, buildComment, buildText } from "../builders";
 import { appendChild, isHelper } from "../ast";
-import { postprocessProgram } from "./helpers";
+import { parseComponentBlockParams, postprocessProgram } from "./helpers";
 import { forEach } from "../utils";
 
 // The HTML elements in this list are speced by
@@ -122,6 +122,7 @@ var tokenHandlers = {
       appendChild(parent, element);
     } else {
       var program = buildProgram(element.children);
+      parseComponentBlockParams(element, program);
       postprocessProgram(program);
       var component = buildComponent(element.tag, element.attributes, program);
       appendChild(parent, component);


### PR DESCRIPTION
Initial attempt for https://github.com/tildeio/htmlbars/issues/117.  There was a fair bit of minor copy-paste here and there, but I wasn't sure whether it's ok or warrants some refactoring to reduce duplication, so I figured showing it first is better.  I also wasn't sure whether I need to add a test to `hydration_compiler_test.js` (and I haven't quite learned the opcodes DSL yet).  And, of course, I hope I chose the right place to do the main processing (the call to `parseComponentBlockParams`).
