### PR TITLE
Introduce concat hook for components and attributes

### DIFF
--- a/packages/htmlbars-compiler/lib/builders.js
+++ b/packages/htmlbars-compiler/lib/builders.js
@@ -21,7 +21,7 @@ export function buildPartial(sexpr, indent) {
   return {
     type: "PartialStatement",
     sexpr: sexpr,
-    indent: indent || ""
+    indent: indent
   };
 }
 
@@ -29,6 +29,14 @@ export function buildComment(value) {
   return {
     type: "CommentStatement",
     value: value,
+  };
+}
+
+
+export function buildConcat(parts) {
+  return {
+    type: "ConcatStatement",
+    parts: parts || []
   };
 }
 
@@ -53,12 +61,11 @@ export function buildComponent(tag, attributes, program) {
   };
 }
 
-export function buildAttr(name, value, quoted) {
+export function buildAttr(name, value) {
   return {
     type: "AttrNode",
     name: name,
-    value: value,
-    quoted: quoted
+    value: value
   };
 }
 
@@ -151,6 +158,7 @@ export default {
   string: buildString,
   boolean: buildBoolean,
   number: buildNumber,
+  concat: buildConcat,
   hash: buildHash,
   pair: buildPair,
   program: buildProgram

--- a/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
+++ b/packages/htmlbars-compiler/lib/compiler/fragment_opcode.js
@@ -56,9 +56,8 @@ FragmentOpcodeCompiler.prototype.component = function () {};
 FragmentOpcodeCompiler.prototype.block = function () {};
 
 FragmentOpcodeCompiler.prototype.attribute = function(attr) {
-  var parts = attr.value;
-  if (parts.length === 1 && parts[0].type === 'TextNode') {
-    this.opcode('setAttribute', [attr.name, parts[0].chars]);
+  if (attr.value.type === 'TextNode') {
+    this.opcode('setAttribute', [attr.name, attr.value.chars]);
   }
 };
 

--- a/packages/htmlbars-compiler/lib/compiler/hydration.js
+++ b/packages/htmlbars-compiler/lib/compiler/hydration.js
@@ -88,12 +88,16 @@ prototype.pushGetHook = function(path) {
 
 prototype.pushSexprHook = function() {
   this.hooks.subexpr = true;
-
   var path = this.stack.pop();
   var params = this.stack.pop();
   var hash = this.stack.pop();
-  
   this.stack.push('subexpr(' + path + ', context, ' + params + ', ' + hash + ', {}, env)');
+};
+
+prototype.pushConcatHook = function() {
+  this.hooks.concat = true;
+  var parts = this.stack.pop();
+  this.stack.push('concat(' + parts + ', env)');
 };
 
 prototype.printSetHook = function(name, index) {
@@ -175,10 +179,11 @@ prototype.printComponentHook = function(morphNum, templateId, blockParamsLength)
 };
 
 prototype.printAttributeHook = function(elementNum, quoted) {
+  this.hooks.attribute = true;
+
   var name = this.stack.pop();
   var value = this.stack.pop();
 
-  this.hooks.attribute = true;
   this.source.push(this.indent + '  attribute(element' + elementNum + ', ' + name + ', ' + quoted + ', context, ' + value + ', {}, env);\n');
 };
 

--- a/packages/htmlbars-compiler/lib/compiler/quoting.js
+++ b/packages/htmlbars-compiler/lib/compiler/quoting.js
@@ -21,7 +21,7 @@ export function quotedArray(list) {
 }
 
 export function hash(pairs) {
-  return "{" + pairs.join(",") + "}";
+  return "{" + pairs.join(", ") + "}";
 }
 
 export function repeat(chars, times) {

--- a/packages/htmlbars-compiler/lib/compiler/template_visitor.js
+++ b/packages/htmlbars-compiler/lib/compiler/template_visitor.js
@@ -167,7 +167,7 @@ TemplateVisitor.prototype.ElementNode = function(element) {
 };
 
 TemplateVisitor.prototype.AttrNode = function(attr) {
-  if (attr.value.type === 'MustacheStatement') {
+  if (attr.value.type !== 'TextNode') {
     this.getCurrentFrame().mustacheCount++;
   }
 };

--- a/packages/htmlbars-compiler/lib/html-parser/helpers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/helpers.js
@@ -1,41 +1,10 @@
 import { usesMorph } from "../ast";
-import {
-  buildText,
-  buildString,
-  buildHash,
-  buildPair,
-  buildSexpr,
-  buildPath
-} from "../builders";
+import { buildText } from "../builders";
 
 // Regex to validate the identifier for block parameters. 
 // Based on the ID validation regex in Handlebars.
+
 var ID_INVERSE_PATTERN = /[!"#%-,\.\/;->@\[-\^`\{-~]/;
-
-
-// Rewrites an array of AttrNodes into a HashNode.
-// MustacheNodes are replaced with their root SexprNode and
-// TextNodes are replaced with StringNodes
-
-export function buildHashFromAttributes(attributes) {
-  var pairs = [];
-
-  for (var i = 0; i < attributes.length; i++) {
-    var attr = attributes[i];
-    var parts = attr.value;
-    var value;
-
-    if (parts.length === 1 && parts[0].type === 'TextNode') {
-      value = buildString(parts[0].chars);
-    } else {
-      value = buildSexpr(buildPath('concat'), attr.value);
-    }
-
-    pairs.push(buildPair(attr.name, value));
-  }
-
-  return buildHash(pairs);
-}
 
 // Checks the component's attributes to see if it uses block params.
 // If it does, registers the block params with the program and

--- a/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
+++ b/packages/htmlbars-compiler/lib/html-parser/token-handlers.js
@@ -1,5 +1,5 @@
 import { buildProgram, buildComponent, buildElement, buildComment, buildText } from "../builders";
-import { appendChild, isHelper } from "../ast";
+import { appendChild } from "../ast";
 import { parseComponentBlockParams, postprocessProgram } from "./helpers";
 import { forEach } from "../utils";
 
@@ -36,21 +36,12 @@ function applyHTMLIntegrationPoint(tag, element){
   }
 }
 
-function unwrapMustache(mustache) {
-  if (isHelper(mustache.sexpr)) {
-    return mustache.sexpr;
-  } else {
-    return mustache.sexpr.path;
-  }
-}
-
 // Except for `mustache`, all tokens are only allowed outside of
 // a start or end tag.
 var tokenHandlers = {
   CommentToken: function(token) {
     var current = this.currentElement();
     var comment = buildComment(token.chars);
-
     appendChild(current, comment);
   },
 
@@ -86,17 +77,17 @@ var tokenHandlers = {
       case "beforeAttributeValue":
         this.tokenizer.state = 'attributeValueUnquoted';
         token.markAttributeQuoted(false);
-        token.addToAttributeValue(unwrapMustache(mustache));
+        token.addToAttributeValue(mustache);
         token.finalizeAttributeValue();
         return;
       case "attributeValueDoubleQuoted":
       case "attributeValueSingleQuoted":
         token.markAttributeQuoted(true);
-        token.addToAttributeValue(unwrapMustache(mustache));
+        token.addToAttributeValue(mustache);
         return;
       case "attributeValueUnquoted":
         token.markAttributeQuoted(false);
-        token.addToAttributeValue(unwrapMustache(mustache));
+        token.addToAttributeValue(mustache);
         return;
       case "beforeAttributeName":
         token.addTagHelper(mustache.sexpr);

--- a/packages/htmlbars-compiler/tests/combined_ast_node-test.js
+++ b/packages/htmlbars-compiler/tests/combined_ast_node-test.js
@@ -88,7 +88,7 @@ test("elements can have empty attributes", function() {
   var t = '<img id="">';
   astEqual(t, b.program([
     b.element("img", [
-      b.attr("id", [ b.text("") ], true)
+      b.attr("id", b.text(""))
     ])
   ]));
 });
@@ -164,7 +164,7 @@ test("Handlebars embedded in an attribute (quoted)", function() {
   var t = 'some <div class="{{foo}}">content</div> done';
   astEqual(t, b.program([
     b.text("some "),
-    b.element("div", [ b.attr("class", [ b.path('foo') ], true) ], [], [
+    b.element("div", [ b.attr("class", b.concat([ b.path('foo') ])) ], [], [
       b.text("content")
     ]),
     b.text(" done")
@@ -175,7 +175,7 @@ test("Handlebars embedded in an attribute (unquoted)", function() {
   var t = 'some <div class={{foo}}>content</div> done';
   astEqual(t, b.program([
     b.text("some "),
-    b.element("div", [ b.attr("class", [ b.path('foo') ], false) ], [], [
+    b.element("div", [ b.attr("class", b.mustache(b.sexpr(b.path('foo')))) ], [], [
       b.text("content")
     ]),
     b.text(" done")
@@ -187,7 +187,7 @@ test("Handlebars embedded in an attribute (sexprs)", function() {
   astEqual(t, b.program([
     b.text("some "),
     b.element("div", [
-      b.attr("class", [ b.sexpr(b.path('foo'), [ b.sexpr(b.path('foo'), [ b.string('abc') ]) ]) ], true)
+      b.attr("class", b.concat([ b.sexpr(b.path('foo'), [ b.sexpr(b.path('foo'), [ b.string('abc') ]) ]) ]))
     ], [], [
       b.text("content")
     ]),
@@ -201,11 +201,11 @@ test("Handlebars embedded in an attribute with other content surrounding it", fu
   astEqual(t, b.program([
     b.text("some "),
     b.element("a", [
-      b.attr("href", [
+      b.attr("href", b.concat([
         b.string("http://"),
         b.path('link'),
         b.string("/")
-      ], true)
+      ]))
     ], [], [
       b.text("content")
     ]),
@@ -224,11 +224,11 @@ test("A more complete embedding example", function() {
     b.mustache(b.sexpr(b.path('some'), [b.string('content')])),
     b.text(' '),
     b.element("div", [
-      b.attr("class", [
+      b.attr("class", b.concat([
         b.path('foo'),
         b.string(' '),
         b.sexpr(b.path('bind-class'), [b.path('isEnabled')], b.hash([b.pair('truthy', b.string('enabled'))]))
-      ], true)
+      ]))
     ], [], [
       b.mustache(b.sexpr(b.path('content')))
     ]),
@@ -274,7 +274,7 @@ test("Involved block helper", function() {
 test("Node helpers", function() {
   var t = "<p {{action 'boom'}} class='bar'>Some content</p>";
   astEqual(t, b.program([
-    b.element('p', [ b.attr('class', [ b.text('bar') ], true) ], [b.sexpr(b.path('action'), [b.string('boom')])], [
+    b.element('p', [ b.attr('class', b.text('bar')) ], [b.sexpr(b.path('action'), [b.string('boom')])], [
       b.text('Some content')
     ])
   ]));
@@ -402,11 +402,11 @@ test("Components", function() {
   astEqual(t, b.program([
     b.text(''),
     b.component('x-foo', [
-      b.attr('a', [ b.text('b') ], false),
-      b.attr('c', [ b.text('d') ], true),
-      b.attr('e', [ b.path('f') ], false),
-      b.attr('id', [ b.path('bar') ], true),
-      b.attr('class', [ b.string('foo-'), b.path('bar') ], true)
+      b.attr('a', b.text('b')),
+      b.attr('c', b.text('d')),
+      b.attr('e', b.mustache(b.sexpr(b.path('f')))),
+      b.attr('id', b.concat([ b.path('bar') ])),
+      b.attr('class', b.concat([ b.string('foo-'), b.path('bar') ]))
     ], b.program([
       b.text(''),
       b.mustache(b.sexpr(b.path('a'))),

--- a/packages/htmlbars-compiler/tests/hydration_compiler_test.js
+++ b/packages/htmlbars-compiler/tests/hydration_compiler_test.js
@@ -166,6 +166,7 @@ test("attribute mustache", function() {
     [ "pushGetHook", [ "foo" ] ],
     [ "pushLiteral", [ "before " ] ],
     [ "prepareArray", [ 3 ] ],
+    [ "pushConcatHook", [ ] ],
     [ "pushLiteral", [ "class" ] ],
     [ "shareElement", [ 0 ] ],
     [ "printAttributeHook", [ 0, true ] ]
@@ -184,6 +185,7 @@ test("attribute helper", function() {
     [ "pushSexprHook", [ ] ],
     [ "pushLiteral", [ "before " ] ],
     [ "prepareArray", [ 3 ] ],
+    [ "pushConcatHook", [ ] ],
     [ "pushLiteral", [ "class" ] ],
     [ "shareElement", [ 0 ] ],
     [ "printAttributeHook", [ 0, true ] ]

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -1,5 +1,3 @@
-import { concat } from "./helpers";
-
 export function content(morph, path, context, params, hash, options, env) {
   var value, helper = lookupHelper(context, path, env);
   if (helper) {
@@ -17,19 +15,11 @@ export function element(domElement, helperName, context, params, hash, options, 
   }
 }
 
-export function attribute(domElement, attributeName, quoted, context, parts, options) {
-  var attrValue;
-
-  if (quoted) {
-    attrValue = concat.call(context, parts, null, options);
+export function attribute(domElement, name, quoted, context, value) {
+  if (value === null) {
+    domElement.removeAttribute(name);
   } else {
-    attrValue = parts[0];
-  }
-
-  if (attrValue === null) {
-    domElement.removeAttribute(attributeName);
-  } else {
-    domElement.setAttribute(attributeName, attrValue);
+    domElement.setAttribute(name, value);
   }
 }
 
@@ -73,6 +63,14 @@ export function component(morph, tagName, context, hash, options, env) {
   morph.update(value);
 }
 
+export function concat(params) {
+  var value = "";
+  for (var i = 0, l = params.length; i < l; i++) {
+    value += params[i];
+  }
+  return value;
+}
+
 function componentFallback(morph, tagName, context, hash, options, env) {
   var element = env.dom.createElement(tagName);
   for (var name in hash) {
@@ -92,6 +90,7 @@ export default {
   element: element,
   attribute: attribute,
   subexpr: subexpr,
+  concat: concat,
   get: get,
   set: set
 };

--- a/packages/htmlbars-runtime/tests/main-test.js
+++ b/packages/htmlbars-runtime/tests/main-test.js
@@ -19,6 +19,7 @@ test("hooks are present", function () {
     "element",
     "attribute",
     "subexpr",
+    "concat",
     "get",
     "set"
   ];


### PR DESCRIPTION
``` hbs
<x-foo a="b" c={{d}} e={{f g}} h="{{i}} {{j k}}"></x-foo>
<foo   a="b" c={{d}} e={{f g}} h="{{i}} {{j k}}"></foo>
```

now compiles to

``` js
(function() {
  var child0 = (function() {
    return {
      isHTMLBars: true,
      cachedFragment: null,
      build: function build(dom) {
        var el0 = dom.createDocumentFragment();
        return el0;
      },
      render: function render(context, env, contextualElement) {
        var dom = env.dom;
        dom.detectNamespace(contextualElement);
        if (this.cachedFragment === null) {
          this.cachedFragment = this.build(dom);
        }
        var fragment = dom.cloneNode(this.cachedFragment, true);
        return fragment;
      }
    };
  }());
  return {
    isHTMLBars: true,
    cachedFragment: null,
    build: function build(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("");
      dom.appendChild(el0, el1);
      var el1 = dom.createTextNode("\n");
      dom.appendChild(el0, el1);
      var el1 = dom.createElement("foo");
      dom.setAttribute(el1,"a","b");
      dom.appendChild(el0, el1);
      return el0;
    },
    render: function render(context, env, contextualElement) {
      var dom = env.dom;
      var hooks = env.hooks, get = hooks.get, subexpr = hooks.subexpr, concat = hooks.concat, component = hooks.component, attribute = hooks.attribute;
      dom.detectNamespace(contextualElement);
      if (this.cachedFragment === null) {
        this.cachedFragment = this.build(dom);
      }
      var fragment = dom.cloneNode(this.cachedFragment, true);
      dom.repairClonedNode(fragment,[0]);
      var element0 = fragment.childNodes[2];
      var morph0 = dom.createUnsafeMorphAt(fragment,0,1,contextualElement);
      component(morph0, "x-foo", context, {"a": "b", "c": get(context, "d", env), "e": subexpr("f", context, [get(context, "g", env)], {}, {}, env), "h": concat([get(context, "i", env), " ", subexpr("j", context, [get(context, "k", env)], {}, {}, env)], env)}, {morph: morph0, template: child0}, env);
      attribute(element0, "c", false, context, get(context, "d", env), {}, env);
      attribute(element0, "e", false, context, subexpr("f", context, [get(context, "g", env)], {}, {}, env), {}, env);
      attribute(element0, "h", true, context, concat([get(context, "i", env), " ", subexpr("j", context, [get(context, "k", env)], {}, {}, env)], env), {}, env);
      return fragment;
    }
  };
}())
```
