### PR TITLE
Fix error line numbers.

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -56,19 +56,21 @@ function equalTokens(fragment, html) {
   deepEqual(fragTokens, htmlTokens);
 }
 
-QUnit.module("HTML-based compiler (output)", {
-  setup: function() {
-    hooks = merge({}, defaultHooks);
-    helpers = merge({}, defaultHelpers);
-    partials = {};
+function commonSetup() {
+  hooks = merge({}, defaultHooks);
+  helpers = merge({}, defaultHelpers);
+  partials = {};
 
-    env = {
-      dom: new DOMHelper(),
-      hooks: hooks,
-      helpers: helpers,
-      partials: partials
-    };
-  }
+  env = {
+    dom: new DOMHelper(),
+    hooks: hooks,
+    helpers: helpers,
+    partials: partials
+  };
+}
+
+QUnit.module("HTML-based compiler (output)", {
+  setup: commonSetup
 });
 
 test("Simple content produces a document fragment", function() {
@@ -972,27 +974,50 @@ test("Block params in HTML syntax - Throws an error on invalid identifiers for p
   }, /Invalid identifier for block parameters: 'foo\[bar\]' in 'as \|foo\[bar\]\|'/);
 });
 
+QUnit.module("HTML-based compiler (invalid HTML errors)", {
+  setup: commonSetup
+});
+
 test("A helpful error message is provided for mismatched start/end tags", function() {
   QUnit.throws(function() {
     compile("<div>\n<p>\nSomething\n\n</div>");
-  }, /Closing tag `div` \(on line 5\) did not match last open tag `p`\./);
+  }, /Closing tag `div` \(on line 5\) did not match last open tag `p` \(on line 2\)\./);
+});
+
+test("error line numbers include comment lines", function() {
+  QUnit.throws(function() {
+    compile("<div>\n<p>\n{{! some comment}}\n\n</div>");
+  }, /Closing tag `div` \(on line 5\) did not match last open tag `p` \(on line 2\)\./);
+});
+
+test("error line numbers include mustache only lines", function() {
+  QUnit.throws(function() {
+    compile("<div>\n<p>\n{{someProp}}\n\n</div>");
+  }, /Closing tag `div` \(on line 5\) did not match last open tag `p` \(on line 2\)\./);
+});
+
+test("error line numbers include block lines", function() {
+  QUnit.throws(function() {
+    compile("<div>\n<p>\n{{#some-comment}}\n{{/some-comment}}\n</div>");
+  }, /Closing tag `div` \(on line 5\) did not match last open tag `p` \(on line 2\)\./);
+});
+
+test("error line numbers include whitespace control mustaches", function() {
+  QUnit.throws(function() {
+    compile("<div>\n<p>\n{{someProp~}}\n\n</div>{{some-comment}}");
+  }, /Closing tag `div` \(on line 5\) did not match last open tag `p` \(on line 2\)\./);
+});
+
+test("error line numbers include multiple mustache lines", function() {
+  QUnit.throws(function() {
+    compile("<div>\n<p>\n{{some-comment}}</div>{{some-comment}}");
+  }, /Closing tag `div` \(on line 3\) did not match last open tag `p` \(on line 2\)\./);
 });
 
 if (document.createElement('div').namespaceURI) {
 
 QUnit.module("HTML-based compiler (output, svg)", {
-  setup: function() {
-    hooks = merge({}, defaultHooks);
-    helpers = merge({}, defaultHelpers);
-    partials = {};
-
-    env = {
-      dom: new DOMHelper(),
-      hooks: hooks,
-      helpers: helpers,
-      partials: partials
-    };
-  }
+  setup: commonSetup
 });
 
 test("The compiler can handle namespaced elements", function() {

--- a/packages/htmlbars-syntax/lib/node-handlers.js
+++ b/packages/htmlbars-syntax/lib/node-handlers.js
@@ -72,6 +72,13 @@ var nodeHandlers = {
   },
 
   ContentStatement: function(content) {
+    var changeLines = 0;
+    if (content.rightStripped) {
+      changeLines = leadingNewlineDifference(content.original, content.value);
+    }
+
+    this.tokenizer.line = this.tokenizer.line + changeLines;
+
     var tokens = this.tokenizer.tokenizePart(content.value);
 
     return forEach(tokens, this.acceptToken, this);
@@ -136,6 +143,21 @@ function switchToHandlebars(processor) {
     processor.acceptToken(token);
     processor.tokenizer.token = null;
   }
+}
+
+function leadingNewlineDifference(original, value) {
+  if (value === '') {
+    // if it is empty, just return the count of newlines
+    // in original
+    return original.split("\n").length - 1;
+  }
+
+  // otherwise, return the number of newlines prior to
+  // `value`
+  var difference = original.split(value)[0];
+  var lines = difference.split(/\n/);
+
+  return lines.length - 1;
 }
 
 export default nodeHandlers;

--- a/packages/htmlbars-syntax/lib/token-handlers.js
+++ b/packages/htmlbars-syntax/lib/token-handlers.js
@@ -56,6 +56,11 @@ var tokenHandlers = {
 
   StartTag: function(tag) {
     var element = buildElement(tag.tagName, tag.attributes, tag.helpers || [], []);
+    element.loc = {
+      start: { line: tag.firstLine, column: tag.firstColumn},
+      end: { line: null, column: null}
+    };
+
     applyNamespace(tag, element, this.currentElement());
     applyHTMLIntegrationPoint(tag, element);
     this.elementStack.push(element);
@@ -108,7 +113,7 @@ var tokenHandlers = {
     if (element.tag !== tag.tagName) {
       throw new Error(
         "Closing tag `" + tag.tagName + "` (on line " + tag.lastLine + ") " +
-        "did not match last open tag `" + element.tag + "`."
+        "did not match last open tag `" + element.tag + "` (on line " + element.loc.start.line + ")."
       );
     }
 


### PR DESCRIPTION
We were using `content.value` but not reading the `rightStripped` or `leftStripped` values from the Handlebars AST. This changes to using the `content.original` which is non-stripped.
