### PR TITLE
Inline Handlebars.Utils.escapeExpression into htmlbars-utils.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -6,7 +6,7 @@ var replace = require('broccoli-string-replace');
 var removeFile = require('broccoli-file-remover');
 var transpileES6 = require('broccoli-es6-module-transpiler');
 var jsHint = require('broccoli-jshint');
-var handlebarsInlineTree = require('./build-support/handlebars-inliner');
+var handlebarsInlinedTrees = require('./build-support/handlebars-inliner');
 var getVersion = require('git-repo-version');
 
 var packages = require('./packages');
@@ -21,7 +21,8 @@ var demos = new Funnel('demos', {
 var ES6Tokenizer = new Funnel(bower+'/simple-html-tokenizer/lib/');
 dependableTrees['simple-html-tokenizer'] = ES6Tokenizer;
 
-dependableTrees['handlebars-inliner'] = handlebarsInlineTree;
+dependableTrees['syntax-handlebars-inliner'] = handlebarsInlinedTrees.syntax;
+dependableTrees['util-handlebars-inliner'] = handlebarsInlinedTrees.util;
 
 function getDependencyTree(depName) {
   var dep = dependableTrees[depName];
@@ -136,7 +137,7 @@ for (var packageName in packages.dependencies) {
   // jsHint tests
   var jsHintLibTree = new Funnel(libTree, {
     include: [new RegExp(packageName), new RegExp(packageName + '.+\.js$')],
-    exclude: [/htmlbars-syntax\/handlebars/],
+    exclude: [/htmlbars-(syntax|util)\/handlebars/],
     destDir: packageName+'-tests/'
   });
   jsHintLibTree = removeFile(jsHintLibTree, {

--- a/build-support/handlebars-inliner.js
+++ b/build-support/handlebars-inliner.js
@@ -1,21 +1,30 @@
 var path = require('path');
 var Funnel = require('broccoli-funnel');
 
-var files = [
-  'handlebars/exception.js',
-  'handlebars/safe-string.js',
-  'handlebars/utils.js',
-  'handlebars/compiler/ast.js',
-  'handlebars/compiler/base.js',
-  'handlebars/compiler/helpers.js',
-  'handlebars/compiler/parser.js',
-  'handlebars/compiler/visitor.js',
-  'handlebars/compiler/whitespace-control.js'
-];
-
 var root = path.join(__dirname, '..', 'node_modules', 'handlebars', 'lib');
 
-module.exports = new Funnel(root, {
-  files: files,
-  destDir: '/htmlbars-syntax'
-});
+module.exports = {
+  syntax: new Funnel(root, {
+    files: [
+      'handlebars/utils.js',
+      'handlebars/exception.js',
+      'handlebars/safe-string.js',
+      'handlebars/compiler/ast.js',
+      'handlebars/compiler/base.js',
+      'handlebars/compiler/helpers.js',
+      'handlebars/compiler/parser.js',
+      'handlebars/compiler/visitor.js',
+      'handlebars/compiler/whitespace-control.js'
+    ],
+    destDir: '/htmlbars-syntax'
+  }),
+
+  util: new Funnel(root, {
+
+    files: [
+      'handlebars/utils.js',
+      'handlebars/safe-string.js'
+    ],
+    destDir: '/htmlbars-util'
+  })
+}

--- a/packages/htmlbars-util/lib/main.js
+++ b/packages/htmlbars-util/lib/main.js
@@ -1,5 +1,7 @@
 import SafeString from './htmlbars-util/safe-string';
+import { escapeExpression } from './htmlbars-util/handlebars/utils';
 
 export {
-  SafeString
+  SafeString,
+  escapeExpression
 };

--- a/packages/htmlbars-util/lib/safe-string.js
+++ b/packages/htmlbars-util/lib/safe-string.js
@@ -1,10 +1,3 @@
-function SafeString(string) {
-  this.string = string;
-}
-
-SafeString.prototype.toString = function() {
-  return "" + this.string;
-};
+import SafeString from './handlebars/safe-string';
 
 export default SafeString;
-

--- a/packages/index.js
+++ b/packages/index.js
@@ -32,24 +32,26 @@ module.exports = {
   dependencies: {
     "htmlbars": {
       node: true,
-      lib: ["handlebars-inliner", "htmlbars-util", "simple-html-tokenizer", "htmlbars-syntax", "htmlbars-compiler", "htmlbars-runtime", "morph"]
+      lib: ["syntax-handlebars-inliner", "htmlbars-util", "simple-html-tokenizer", "htmlbars-syntax", "htmlbars-compiler", "htmlbars-runtime", "morph"]
     },
     "htmlbars-syntax": {
       node: true,
-      lib: ["handlebars-inliner", "htmlbars-util", "simple-html-tokenizer"]
+      lib: ["syntax-handlebars-inliner", "htmlbars-util", "simple-html-tokenizer"]
     },
     "htmlbars-compiler": {
       node: true,
-      lib: ["handlebars-inliner", "htmlbars-util", "simple-html-tokenizer", "htmlbars-syntax"],
+      lib: ["syntax-handlebars-inliner", "htmlbars-util", "simple-html-tokenizer", "htmlbars-syntax"],
       test: ["htmlbars-runtime", "morph", "htmlbars-test-helpers"]
     },
     "htmlbars-runtime": {
       lib: ["htmlbars-util", "morph"]
     },
     "morph": {
-      test: ["htmlbars-util", "htmlbars-test-helpers"]
+      test: ["util-handlebars-inliner", "htmlbars-util", "htmlbars-test-helpers"]
     },
-    "htmlbars-util": { },
+    "htmlbars-util": {
+      lib: ["util-handlebars-inliner"]
+    },
     "htmlbars-test-helpers": { }
   }
 };


### PR DESCRIPTION
`escapeExpression` is needed in Ember, and once we remove `Handlebars` itself as a requirement we will need to get this from HTMLBars.
