### PR TITLE
Throw error if unquoted attribute value is made up of more than one node

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -132,6 +132,27 @@ test("unquoted attribute expression is string", function() {
   equalTokens(fragment, '<input value="oh my">');
 });
 
+test("unquoted attribute expression works when followed by another attribute", function() {
+
+  var template = compile('<input value={{funstuff}} name="Alice">');
+  var fragment = template.render({funstuff: "oh my"}, env);
+
+  equalTokens(fragment, '<input value="oh my" name="Alice">');
+});
+
+test("Unquoted attribute value with multiple nodes throws an exception", function () {
+  expect(4);
+
+  QUnit.throws(function() { compile('<img class=foo{{bar}}>'); }, expectedError(1));
+  QUnit.throws(function() { compile('<img class={{foo}}{{bar}}>'); }, expectedError(1));
+  QUnit.throws(function() { compile('<img \nclass={{foo}}bar>'); }, expectedError(2));
+  QUnit.throws(function() { compile('<div \nclass\n=\n{{foo}}&amp;bar ></div>'); }, expectedError(4));
+
+  function expectedError(line) {
+    return new Error("Unquoted attribute value must be a single string or mustache (line " + line + ")");
+  }
+});
+
 test("Simple elements can have arbitrary attributes", function() {
   var template = compile("<div data-some-data='foo'>content</div>");
   var fragment = template.render({}, env);

--- a/packages/htmlbars-syntax/lib/token-handlers.js
+++ b/packages/htmlbars-syntax/lib/token-handlers.js
@@ -86,15 +86,10 @@ var tokenHandlers = {
         this.tokenizer.state = 'attributeValueUnquoted';
         token.markAttributeQuoted(false);
         token.addToAttributeValue(mustache);
-        token.finalizeAttributeValue();
         return;
       case "attributeValueDoubleQuoted":
       case "attributeValueSingleQuoted":
-        token.markAttributeQuoted(true);
-        token.addToAttributeValue(mustache);
-        return;
       case "attributeValueUnquoted":
-        token.markAttributeQuoted(false);
         token.addToAttributeValue(mustache);
         return;
       case "beforeAttributeName":

--- a/packages/htmlbars-syntax/lib/tokens.js
+++ b/packages/htmlbars-syntax/lib/tokens.js
@@ -18,6 +18,14 @@ StartTag.prototype.addToAttributeName = function(char) {
 StartTag.prototype.addToAttributeValue = function(char) {
   var value = this.currentAttribute.value;
 
+  if (!this.currentAttribute.quoted && value.length > 0 &&
+      (char.type === 'MustacheStatement' || value[0].type === 'MustacheStatement')) {
+    // Get the line number from a mustache, whether it's the one to add or the one already added
+    var mustache = char.type === 'MustacheStatement' ? char : value[0],
+        line = mustache.loc.start.line;
+    throw new Error("Unquoted attribute value must be a single string or mustache (line " + line + ")");
+  }
+
   if (typeof char === 'object') {
     if (char.type === 'MustacheStatement') {
       value.push(char);


### PR DESCRIPTION
Resolves https://github.com/tildeio/htmlbars/issues/182.

The deleted lines in `token-handlers.js` were redundant and were mostly removed just to clean it up a bit.  But line 89 in particular needed to go because otherwise we wouldn't be able to get the line number with something like `class={{foo}}bar` (by the time we get to adding `bar` we'd no longer be on an attribute with a mustache from which to get the line number). 
