### PR TITLE
Update for latest simple-html-tokenizer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "htmlbars",
   "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#1a48c72e56200ae6c326d0821376ae95fbaa721b"
+    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#f9d1a97539c31fd25ac7db882105df9d7d6e28ba"
   },
   "devDependencies": {
     "loader": "stefanpenner/loader.js#7f79173fd5c61dc256af9aa01c56d50ebfec10fe",

--- a/packages/htmlbars-syntax/lib/parser.js
+++ b/packages/htmlbars-syntax/lib/parser.js
@@ -1,5 +1,7 @@
 import { parse } from "./handlebars/compiler/base";
 import { Tokenizer } from "../simple-html-tokenizer";
+import EntityParser from "../simple-html-tokenizer/entity-parser";
+import fullCharRefs from "../simple-html-tokenizer/char-refs/full";
 import nodeHandlers from "./node-handlers";
 import tokenHandlers from "./token-handlers";
 
@@ -19,7 +21,7 @@ export function preprocess(html, options) {
 function HTMLProcessor(source, options) {
   this.options = options || {};
   this.elementStack = [];
-  this.tokenizer = new Tokenizer('');
+  this.tokenizer = new Tokenizer('', new EntityParser(fullCharRefs));
   this.nodeHandlers = nodeHandlers;
   this.tokenHandlers = tokenHandlers;
   this.source = source.split(/(?:\r\n?|\n)/g);

--- a/packages/htmlbars-syntax/lib/token-handlers.js
+++ b/packages/htmlbars-syntax/lib/token-handlers.js
@@ -42,7 +42,7 @@ function applyHTMLIntegrationPoint(tag, element){
 // Except for `mustache`, all tokens are only allowed outside of
 // a start or end tag.
 var tokenHandlers = {
-  CommentToken: function(token) {
+  Comment: function(token) {
     var current = this.currentElement();
     var comment = buildComment(token.chars);
     appendChild(current, comment);


### PR DESCRIPTION
Resolves https://github.com/tildeio/htmlbars/issues/197 (at least all the tests pass).  I assumed we want to use `char-refs/full` rather than `char-refs/min`.  If we wanted to use `min` instead we'd need to modify the `fragment` test `converts entities to their char/string equivalent`, because it uses `&NotGreaterFullEqual;` which causes it to fail with `min`.
