### PR TITLE
Escape backslashes correctly

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -209,6 +209,10 @@ test("The compiler can handle quotes", function() {
   compilesTo('<div>"This is a title," we\'re on a boat</div>');
 });
 
+test("The compiler can handle backslashes", function() {
+  compilesTo('<div>This is a backslash: \\</div>');
+});
+
 test("The compiler can handle newlines", function() {
   compilesTo("<div>common\n\nbro</div>");
 });

--- a/packages/htmlbars-util/lib/quoting.js
+++ b/packages/htmlbars-util/lib/quoting.js
@@ -1,5 +1,8 @@
 function escapeString(str) {
-  return str.replace(/"/g, '\\"').replace(/\n/g, "\\n");
+  str = str.replace(/\\/g, "\\\\");
+  str = str.replace(/"/g, '\\"');
+  str = str.replace(/\n/g, "\\n");
+  return str;
 }
 
 export { escapeString };


### PR DESCRIPTION
This fixes the quoting helpers so that `\` is escaped to `\\`.
