### PR TITLE
Delay fragment caching until second template run

### DIFF
--- a/packages/htmlbars-compiler/lib/template-compiler.js
+++ b/packages/htmlbars-compiler/lib/template-compiler.js
@@ -94,15 +94,24 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     indent+'  return {\n' +
     indent+'    isHTMLBars: true,\n' +
     indent+'    cachedFragment: null,\n' +
+    indent+'    hasRendered: false,\n' +
     indent+'    build: ' + fragmentProgram + ',\n' +
     indent+'    render: function render(' + templateSignature + ') {\n' +
     indent+'      var dom = env.dom;\n' +
     this.getHydrationHooks(indent + '      ', this.hydrationCompiler.hooks) +
     indent+'      dom.detectNamespace(contextualElement);\n' +
+    indent+'      var fragment;\n' +
     indent+'      if (this.cachedFragment === null) {\n' +
-    indent+'        this.cachedFragment = this.build(dom);\n' +
+    indent+'        fragment = this.build(dom);\n' +
+    indent+'        if (this.hasRendered) {\n' +
+    indent+'          this.cachedFragment = fragment;\n' +
+    indent+'        } else {\n' +
+    indent+'          this.hasRendered = true;\n' +
+    indent+'        }\n' +
     indent+'      }\n' +
-    indent+'      var fragment = dom.cloneNode(this.cachedFragment, true);\n' +
+    indent+'      if (this.cachedFragment) {\n' +
+    indent+'        fragment = dom.cloneNode(this.cachedFragment, true);\n' +
+    indent+'      }\n' +
     hydrationProgram +
     indent+'      return fragment;\n' +
     indent+'    }\n' +


### PR DESCRIPTION
Closes #101. This seems to have some impact on initial render, but from my tests with an Ember app rendering 5 templates with lots of DOM I'm only seeing ~5ms improvement in Chrome and ~10-15ms improvement on IE10. No big win, but still seems worth-while and reasonable.
