### PR TITLE
Abstract child node lookup into `childAt`

### DIFF
--- a/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
@@ -5,7 +5,7 @@ function HydrationJavaScriptCompiler() {
   this.stack = [];
   this.source = [];
   this.mustaches = [];
-  this.parents = ['fragment'];
+  this.parents = [['fragment']];
   this.parentCount = 0;
   this.morphs = [];
   this.fragmentProcessing = [];
@@ -21,7 +21,7 @@ prototype.compile = function(opcodes, options) {
   this.mustaches.length = 0;
   this.source.length = 0;
   this.parents.length = 1;
-  this.parents[0] = 'fragment';
+  this.parents[0] = ['fragment'];
   this.morphs.length = 0;
   this.fragmentProcessing.length = 0;
   this.parentCount = 0;
@@ -218,11 +218,14 @@ prototype.repairClonedNode = function(blankChildTextNodes, isElementChecked) {
 prototype.shareElement = function(elementNum){
   var elementNodesName = "element" + elementNum;
   this.fragmentProcessing.push('var '+elementNodesName+' = '+this.getParent()+';');
-  this.parents[this.parents.length-1] = elementNodesName;
+  this.parents[this.parents.length-1] = [elementNodesName];
 };
 
 prototype.consumeParent = function(i) {
-  this.parents.push(this.getParent() + '.childNodes[' + i + ']');
+  var newParent = this.lastParent().slice();
+  newParent.push(i);
+
+  this.parents.push(newParent);
 };
 
 prototype.popParent = function() {
@@ -230,5 +233,16 @@ prototype.popParent = function() {
 };
 
 prototype.getParent = function() {
+  var last = this.lastParent().slice();
+  var frag = last.shift();
+
+  if (!last.length) {
+    return frag;
+  }
+
+  return 'dom.childAt(' + frag + ', [' + last.join(', ') + '])';
+};
+
+prototype.lastParent = function() {
   return this.parents[this.parents.length-1];
 };

--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -130,6 +130,16 @@ prototype.appendChild = function(element, childElement) {
   return element.appendChild(childElement);
 };
 
+prototype.childAt = function(element, indices) {
+  var child = element;
+
+  for (var i = 0; i < indices.length; i++) {
+    child = child.childNodes[indices[i]];
+  }
+
+  return child;
+};
+
 prototype.appendText = function(element, text) {
   return element.appendChild(this.document.createTextNode(text));
 };


### PR DESCRIPTION
Currently, opcodes that look up child nodes are hard-coded to generate
a chain of `childNodes[idx]` lookups.

This change abstracts that lookup by adding a `childAt` method to the
DOM helper, which takes an element and an array of indices to look up.

For example, the old code:

``` js
fragment.childNodes[0].childNodes[1].childNodes[0];
```

is replaced by:

``` js
dom.childAt(fragment, [0, 1, 0]);
```

This change allows us to abstract child node lookup so that the elements
returned from e.g. `dom.cloneNode` or `dom.createDocumentFragment` do
not have to implement a subset of the DOM API, and helps keep all of the
abstraction in the single DOM helper object.
