### PR TITLE
Fix exiting namespace when it's the last child (#223)

### DIFF
--- a/packages/htmlbars-compiler/lib/template-visitor.js
+++ b/packages/htmlbars-compiler/lib/template-visitor.js
@@ -5,9 +5,7 @@ function elementIntroducesNamespace(element, parentElement){
     // Root element. Those that have a namespace are entered.
     (!parentElement && element.namespaceURI) ||
     // Inner elements to a namespace
-    ( parentElement &&
-      ( !element.isHTMLIntegrationPoint && parentElement.namespaceURI !== element.namespaceURI )
-    )
+    (parentElement && parentElement.namespaceURI !== element.namespaceURI)
   );
 }
 
@@ -131,15 +129,11 @@ TemplateVisitor.prototype.ElementNode = function(element) {
     parentNode.type === 'Program' && parentFrame.childCount === 1
   ];
 
-  var lastNode = parentFrame.childIndex === parentFrame.childCount-1,
-      introducesNamespace = elementIntroducesNamespace(element, parentFrame.parentNode);
-  if ( !lastNode && introducesNamespace ) {
+  var introducesNamespace = elementIntroducesNamespace(element, parentFrame.parentNode);
+  if ( introducesNamespace ) {
     elementFrame.actions.push(['setNamespace', [parentNode.namespaceURI]]);
   }
   elementFrame.actions.push(['closeElement', actionArgs]);
-  if ( !lastNode && element.isHTMLIntergrationPoint ) {
-    elementFrame.actions.push(['setNamespace', []]);
-  }
 
   for (var i = element.attributes.length - 1; i >= 0; i--) {
     this.visit(element.attributes[i]);
@@ -150,9 +144,6 @@ TemplateVisitor.prototype.ElementNode = function(element) {
     this.visit(element.children[i]);
   }
 
-  if ( element.isHTMLIntergrationPoint ) {
-    elementFrame.actions.push(['setNamespace', []]);
-  }
   elementFrame.actions.push(['openElement', actionArgs.concat([
     elementFrame.mustacheCount, elementFrame.blankChildTextNodes.reverse() ])]);
   if ( introducesNamespace ) {

--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -1034,6 +1034,15 @@ test("The compiler pops back to the correct namespace", function() {
   equalTokens(fragment, html);
 });
 
+test("The compiler pops back to the correct namespace even if exiting last child", function () {
+  var html = '<div><svg></svg></div><div></div>';
+  var fragment = compile(html).render({}, env);
+
+  equal(fragment.firstChild.namespaceURI, xhtmlNamespace, "first div's namespace is xhtmlNamespace");
+  equal(fragment.firstChild.firstChild.namespaceURI, svgNamespace, "svg's namespace is svgNamespace");
+  equal(fragment.lastChild.namespaceURI, xhtmlNamespace, "last div's namespace is xhtmlNamespace");
+});
+
 test("The compiler preserves capitalization of tags", function() {
   var html = '<svg><linearGradient id="gradient"></linearGradient></svg>';
   var template = compile(html);


### PR DESCRIPTION
Fixes https://github.com/tildeio/htmlbars/issues/223 (which came from https://github.com/emberjs/ember.js/issues/9971 )
