### PR TITLE
Fix test failures on Internet Explorer (#229)

### DIFF
--- a/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
@@ -213,10 +213,10 @@ prototype.createAttrMorph = function(attrMorphNum, elementNum, name, escaped) {
 
 prototype.repairClonedNode = function(blankChildTextNodes, isElementChecked) {
   var parent = this.getParent(),
-      processing = 'dom.repairClonedNode('+parent+','+
+      processing = 'if (this.cachedFragment) { dom.repairClonedNode('+parent+','+
                    array(blankChildTextNodes)+
                    ( isElementChecked ? ',true' : '' )+
-                   ');';
+                   '); }';
   this.fragmentProcessing.push(
     processing
   );

--- a/packages/htmlbars-compiler/tests/fragment-test.js
+++ b/packages/htmlbars-compiler/tests/fragment-test.js
@@ -23,7 +23,7 @@ function fragmentFor(ast) {
   return fn(new DOMHelper());
 }
 
-function hydratorFor(ast) {
+function hydratorFor(ast, cachedFragment) {
   /* jshint evil: true */
   var hydrate = new HydrationOpcodeCompiler();
   var opcodes = hydrate.compile(ast);
@@ -34,7 +34,8 @@ function hydratorFor(ast) {
   for (var hook in hydrate2.hooks) {
     hookVars.push(hook + ' = hooks.' + hook);
   }
-  program =  'var ' + hookVars.join(', ') + ';\n' + program;
+  program =  'var ' + hookVars.join(', ') + ';\n' +
+             'this.cachedFragment = ' + !!cachedFragment + ';\n' + program;
   return new Function("fragment", "context", "dom", "hooks", "env", "contextualElement", program);
 }
 
@@ -129,7 +130,7 @@ test('test auto insertion of text nodes for needed edges a fragment with morph m
   var ast = preprocess("{{first}}<p>{{second}}</p>{{third}}");
   var dom = new DOMHelper();
   var fragment = dom.cloneNode(fragmentFor(ast), true);
-  var hydrate = hydratorFor(ast);
+  var hydrate = hydratorFor(ast, true);
 
   var morphs = [];
   var fakeMorphDOM = new DOMHelper();

--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -149,7 +149,7 @@ prototype.appendText = function(element, text) {
 };
 
 prototype.setAttribute = function(element, name, value) {
-  element.setAttribute(name, value);
+  element.setAttribute(name, String(value));
 };
 
 prototype.removeAttribute = function(element, name) {

--- a/packages/morph/tests/attr-morph-test.js
+++ b/packages/morph/tests/attr-morph-test.js
@@ -37,11 +37,11 @@ test("can update attribute", function(){
 test("can update svg attribute", function(){
   domHelper.setNamespace(svgNamespace);
   var element = domHelper.createElement('svg');
-  var morph = domHelper.createAttrMorph(element, 'viewBox');
-  morph.setContent('0 0 0 0');
-  equal(element.getAttribute('viewBox'), '0 0 0 0', 'svg attr is set');
+  var morph = domHelper.createAttrMorph(element, 'height');
+  morph.setContent('50%');
+  equal(element.getAttribute('height'), '50%', 'svg attr is set');
   morph.setContent(null);
-  equal(element.getAttribute('viewBox'), undefined, 'svg attr is removed');
+  equal(element.getAttribute('height'), undefined, 'svg attr is removed');
 });
 
 test("can update style attribute", function(){


### PR DESCRIPTION
Fixes https://github.com/tildeio/htmlbars/issues/229.

-- Convert value for setAttribute() to string
-- Make repairClonedNode() safe to call on uncloned nodes (e.g. first rendering)

Tested with IE 11, and I expect based on what was failing before that it will also take care of IE 9 and 10, but let's see what the saucelabs tests say.  My first approach was to not call `repairClonedNode()` the first time (by modifying the code for `template.render()`), but it made a different test fail, and having the dom helper handle it seems more appropriate anyway.

The added tests were not strictly speaking required, since there were other failing tests, but these make the failure's cause explicit.

[EDIT: passes IE 8+]