### PR TITLE
Simplify namespace handling

### DIFF
--- a/packages/htmlbars-compiler/lib/template-visitor.js
+++ b/packages/htmlbars-compiler/lib/template-visitor.js
@@ -1,14 +1,5 @@
 var push = Array.prototype.push;
 
-function elementIntroducesNamespace(element, parentElement){
-  return (
-    // Root element. Those that have a namespace are entered.
-    (!parentElement && element.namespaceURI) ||
-    // Inner elements to a namespace
-    (parentElement && parentElement.namespaceURI !== element.namespaceURI)
-  );
-}
-
 function Frame() {
   this.parentNode = null;
   this.children = null;
@@ -129,10 +120,6 @@ TemplateVisitor.prototype.ElementNode = function(element) {
     parentNode.type === 'Program' && parentFrame.childCount === 1
   ];
 
-  var introducesNamespace = elementIntroducesNamespace(element, parentFrame.parentNode);
-  if ( introducesNamespace ) {
-    elementFrame.actions.push(['setNamespace', [parentNode.namespaceURI]]);
-  }
   elementFrame.actions.push(['closeElement', actionArgs]);
 
   for (var i = element.attributes.length - 1; i >= 0; i--) {
@@ -146,9 +133,6 @@ TemplateVisitor.prototype.ElementNode = function(element) {
 
   elementFrame.actions.push(['openElement', actionArgs.concat([
     elementFrame.mustacheCount, elementFrame.blankChildTextNodes.reverse() ])]);
-  if ( introducesNamespace ) {
-    elementFrame.actions.push(['setNamespace', [element.namespaceURI]]);
-  }
   this.popFrame();
 
   // Propagate the element's frame state to the parent frame

--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -1004,9 +1004,9 @@ test("The compiler sets a namespace on an HTML integration point", function() {
   var fragment = template.render({}, env);
 
   equal( fragment.namespaceURI, svgNamespace,
-         "creates the path element with a namespace" );
+         "creates the svg element with a namespace" );
   equal( fragment.childNodes[0].namespaceURI, svgNamespace,
-         "creates the path element with a namespace" );
+         "creates the foreignObject element with a namespace" );
   equalTokens(fragment, html);
 });
 
@@ -1016,7 +1016,7 @@ test("The compiler does not set a namespace on an element inside an HTML integra
   var fragment = template.render({}, env);
 
   equal( fragment.childNodes[0].childNodes[0].namespaceURI, xhtmlNamespace,
-         "creates the path element with a namespace" );
+         "creates the div inside the foreignObject without a namespace" );
   equalTokens(fragment, html);
 });
 
@@ -1026,11 +1026,11 @@ test("The compiler pops back to the correct namespace", function() {
   var fragment = template.render({}, env);
 
   equal( fragment.childNodes[0].namespaceURI, svgNamespace,
-         "creates the path element with a namespace" );
+         "creates the first svg element with a namespace" );
   equal( fragment.childNodes[1].namespaceURI, svgNamespace,
-         "creates the path element with a namespace" );
+         "creates the second svg element with a namespace" );
   equal( fragment.childNodes[2].namespaceURI, xhtmlNamespace,
-         "creates the path element with a namespace" );
+         "creates the div element without a namespace" );
   equalTokens(fragment, html);
 });
 

--- a/packages/htmlbars-compiler/tests/template-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/template-compiler-test.js
@@ -10,6 +10,14 @@ QUnit.module("TemplateCompiler");
 
 var dom, hooks, helpers;
 
+function countNamespaceChanges(template) {
+  var ast = preprocess(template);
+  var compiler = new TemplateCompiler();
+  var program = compiler.compile(ast);
+  var matches = program.match(/dom\.setNamespace/g);
+  return matches ? matches.length : 0;
+}
+
 test("it works", function testFunction() {
   /* jshint evil: true */
   var ast = preprocess('<div>{{#if working}}Hello {{firstName}} {{lastName}}!{{/if}}</div>');
@@ -40,5 +48,13 @@ test("it works", function testFunction() {
   };
   var frag = template.render(context, env, document.body);
   equalHTML(frag, '<div>Hello Kris Selden!</div>');
+});
+
+test("it omits unnecessary namespace changes", function () {
+  equal(countNamespaceChanges('<div></div>'), 0);  // sanity check
+  equal(countNamespaceChanges('<div><svg></svg></div><svg></svg>'), 1);
+  equal(countNamespaceChanges('<div><svg></svg></div><div></div>'), 2);
+  equal(countNamespaceChanges('<div><svg><title>foobar</title></svg></div><svg></svg>'), 1);
+  equal(countNamespaceChanges('<div><svg><title><h1>foobar</h1></title></svg></div><svg></svg>'), 3);
 });
 

--- a/packages/htmlbars-syntax/lib/token-handlers.js
+++ b/packages/htmlbars-syntax/lib/token-handlers.js
@@ -17,28 +17,6 @@ forEach(voidTagNames.split(" "), function(tagName) {
   voidMap[tagName] = true;
 });
 
-var svgNamespace = "http://www.w3.org/2000/svg",
-    // http://www.w3.org/html/wg/drafts/html/master/syntax.html#html-integration-point
-    svgHTMLIntegrationPoints = {'foreignObject':true, 'desc':true, 'title':true};
-
-function applyNamespace(tag, element, currentElement){
-  if (tag.tagName === 'svg') {
-    element.namespaceURI = svgNamespace;
-  } else if (
-    currentElement.type === 'ElementNode' &&
-    currentElement.namespaceURI &&
-    !currentElement.isHTMLIntegrationPoint
-  ) {
-    element.namespaceURI = currentElement.namespaceURI;
-  }
-}
-
-function applyHTMLIntegrationPoint(tag, element){
-  if (svgHTMLIntegrationPoints[tag.tagName]) {
-    element.isHTMLIntegrationPoint = true;
-  }
-}
-
 // Except for `mustache`, all tokens are only allowed outside of
 // a start or end tag.
 var tokenHandlers = {
@@ -61,8 +39,6 @@ var tokenHandlers = {
       end: { line: null, column: null}
     };
 
-    applyNamespace(tag, element, this.currentElement());
-    applyHTMLIntegrationPoint(tag, element);
     this.elementStack.push(element);
     if (voidMap.hasOwnProperty(tag.tagName) || tag.selfClosing) {
       tokenHandlers.EndTag.call(this, tag);

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -3,21 +3,7 @@ import { preprocess } from "../htmlbars-syntax/parser";
 
 import b from "../htmlbars-syntax/builders";
 
-var svgNamespace = "http://www.w3.org/2000/svg";
-
 QUnit.module("HTML-based compiler (AST)");
-
-function svgElement(tagName, attributes, helpers, children) {
-  var e = b.element(tagName, attributes, helpers, children);
-  e.namespaceURI = svgNamespace;
-  return e;
-}
-
-function svgHTMLIntegrationPoint(tagName, attributes, helpers, children) {
-  var e = svgElement(tagName, attributes, helpers, children);
-  e.isHTMLIntegrationPoint = true;
-  return e;
-}
 
 function normalizeNode(obj) {
   if (obj && typeof obj === 'object') {
@@ -118,7 +104,7 @@ test("elements can have empty attributes", function() {
 test("svg content", function() {
   var t = "<svg></svg>";
   astEqual(t, b.program([
-    svgElement("svg")
+    b.element("svg")
   ]));
 });
 
@@ -135,7 +121,7 @@ test("html content with svg content inline", function() {
   var t = '<div><svg></svg></div>';
   astEqual(t, b.program([
     b.element("div", [], [], [
-      svgElement("svg")
+      b.element("svg")
     ])
   ]));
 });
@@ -145,8 +131,8 @@ function buildIntegrationPointTest(integrationPoint){
   return function integrationPointTest(){
     var t = '<svg><'+integrationPoint+'><div></div></'+integrationPoint+'></svg>';
     astEqual(t, b.program([
-      svgElement("svg", [], [], [
-        svgHTMLIntegrationPoint(integrationPoint, [], [], [
+      b.element("svg", [], [], [
+        b.element(integrationPoint, [], [], [
           b.element("div")
         ])
       ])


### PR DESCRIPTION
Follow-up on https://github.com/tildeio/htmlbars/pull/228:

-- Omit unnecessary namespace changes in fragment generation
-- Consolidate namespace handling into one place
-- Correct assertion messages in some SVG-related tests
