### PR TITLE
Remove extra comma to work on JScript

### DIFF
--- a/packages/htmlbars-syntax/lib/builders.js
+++ b/packages/htmlbars-syntax/lib/builders.js
@@ -28,7 +28,7 @@ export function buildPartial(sexpr, indent) {
 export function buildComment(value) {
   return {
     type: "CommentStatement",
-    value: value,
+    value: value
   };
 }
 


### PR DESCRIPTION
This commit fixes a problem on JScript.
(Such as https://github.com/emberjs/ember-rails/pull/419#issuecomment-68276901 )

I wish some transpiler resolve such problem...
