### PR TITLE
Use correct namespace in parseHTML() (ember #9948)

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -1086,6 +1086,22 @@ test("svg can live with hydration", function() {
     "svg namespace inside a block is present" );
 });
 
+test("top-level unsafe morph uses the correct namespace", function() {
+  var template = compile('<svg></svg>{{{foo}}}');
+  var fragment = template.render({ foo: '<span>FOO</span>' }, env, document.body);
+
+  equal(fragment.textContent, 'FOO', 'element from unsafe morph is displayed');
+  equal(fragment.childNodes[1].namespaceURI, xhtmlNamespace, 'element from unsafe morph has correct namespace');
+});
+
+test("nested unsafe morph uses the correct namespace", function() {
+  var template = compile('<svg>{{{foo}}}</svg><div></div>');
+  var fragment = template.render({ foo: '<path></path>' }, env, document.body);
+
+  equal(fragment.childNodes[0].childNodes[0].namespaceURI, svgNamespace,
+        'element from unsafe morph has correct namespace');
+});
+
 test("svg can take some hydration", function() {
   var template = compile('<div><svg>{{name}}</svg></div>');
 

--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -29,10 +29,6 @@ var ignoresCheckedAttribute = doc && (function(document){
   return !clonedElement.checked;
 })(doc);
 
-function isSVG(ns){
-  return ns === svgNamespace;
-}
-
 // This is not the namespace of the element, but of
 // the elements inside that elements.
 function interiorNamespace(element){
@@ -319,12 +315,7 @@ prototype.appendMorph = function(element, contextualElement) {
 };
 
 prototype.parseHTML = function(html, contextualElement) {
-  var isSVGContent = (
-    isSVG(this.namespace) &&
-    !svgHTMLIntegrationPoints[contextualElement.tagName]
-  );
-
-  if (isSVGContent) {
+  if (interiorNamespace(contextualElement) === svgNamespace) {
     return buildSVGDOM(html, this);
   } else {
     var nodes = buildHTMLDOM(html, contextualElement, this);


### PR DESCRIPTION
This was the cause of https://github.com/emberjs/ember.js/issues/9948, and should take care of it.  The immediate problem was that the dom helper was left with the last namespace used in `build()` function.  But, more broadly, I think the appropriate namespace  for `parseHTML()` is that for the morph's contextual element (i.e. either its parent or the template's contextual element), rather than always the template's.  The two tests I added are really testing the same thing, but they cover what seem like important cases, so I figured I should include both.  



[Deleted: some mistaken tangential speculation... later findings instead:
With chrome, `parseHTML` works fine for svg stuff even if it goes down the `else` branch.  As a result, the second test I added was passing in chrome even before the fix, but it was failing in other browsers and passes after the fix.
]