### PR TITLE
Introduce a childAtIndex abstraction

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -144,6 +144,16 @@ prototype.childAt = function(element, indices) {
   return child;
 };
 
+prototype.childAtIndex = function(element, index) {
+  var child = element.firstChild;
+
+  for (var i = 0; child && index !== i; i++) {
+    child = child.nextSibling;
+  }
+
+  return child;
+};
+
 prototype.appendText = function(element, text) {
   return element.appendChild(this.document.createTextNode(text));
 };
@@ -246,7 +256,7 @@ prototype.repairClonedNode = function(element, blankChildTextNodes, isChecked){
     for (var i=0, len=blankChildTextNodes.length;i<len;i++){
       var textNode = this.document.createTextNode(''),
           offset = blankChildTextNodes[i],
-          before = element.childNodes[offset];
+          before = this.childAtIndex(element, offset);
       if (before) {
         element.insertBefore(textNode, before);
       } else {
@@ -290,9 +300,8 @@ prototype.createUnsafeMorph = function(parent, start, end, contextualElement){
 // This helper is just to keep the templates good looking,
 // passing integers instead of element references.
 prototype.createMorphAt = function(parent, startIndex, endIndex, contextualElement){
-  var childNodes = parent.childNodes,
-      start = startIndex === -1 ? null : childNodes[startIndex],
-      end = endIndex === -1 ? null : childNodes[endIndex];
+  var start = startIndex === -1 ? null : this.childAtIndex(parent, startIndex),
+      end = endIndex === -1 ? null : this.childAtIndex(parent, endIndex);
   return this.createMorph(parent, start, end, contextualElement);
 };
 

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -26,6 +26,19 @@ test('#createElement', function(){
   equalHTML(node, '<div></div>');
 });
 
+test('#childAtIndex', function() {
+  var node = dom.createElement('div');
+
+  var child1 = dom.createElement('p');
+  var child2 = dom.createElement('img');
+
+  dom.appendChild(node, child1);
+  equal(dom.childAtIndex(node, 0).tagName, 'P');
+
+  dom.insertBefore(node, child2, child1);
+  equal(dom.childAtIndex(node, 0).tagName, 'IMG');
+});
+
 test('#appendText adds text', function(){
   var node = dom.createElement('div');
   var text = dom.appendText(node, 'Howdy');


### PR DESCRIPTION
Previously, child nodes were being looked up directly via an element’s
`childNodes` array. However, @krisselden had some concerns around
performance and our future ability to do things like diffing if we have
to precisely simulate the behavior of `childNodes`.

This commit introduces a new `childAtIndex` abstraction that allows us
to create an alternate implementation that walks a linked list instead
of assuming an array implementation.