### PR TITLE
Call `String` on value in `setAttributeNS` (for IE 10-11)

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -149,7 +149,7 @@ prototype.setAttribute = function(element, name, value) {
 };
 
 prototype.setAttributeNS = function(element, namespace, name, value) {
-  element.setAttributeNS(namespace, name, value);
+  element.setAttributeNS(namespace, name, String(value));
 };
 
 prototype.removeAttribute = function(element, name) {


### PR DESCRIPTION
We may want to handle `null` differently in the future as @mixonic has been considering, but for now this should eliminate the distracting failures in IE 10 and 11.  Not sure about IE 8, it probably has its own issues.