### PR TITLE
Add namespace detection in `AttrMorph`

### DIFF
--- a/packages/htmlbars-compiler/lib/fragment-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/fragment-opcode-compiler.js
@@ -1,5 +1,6 @@
 import TemplateVisitor from "./template-visitor";
-import { processOpcodes, getNamespace } from "./utils";
+import { processOpcodes } from "./utils";
+import { getAttrNamespace } from "../htmlbars-util";
 import { forEach } from "../htmlbars-util/array-utils";
 
 function FragmentOpcodeCompiler() {
@@ -60,7 +61,7 @@ FragmentOpcodeCompiler.prototype.block = function () {};
 FragmentOpcodeCompiler.prototype.attribute = function(attr) {
   if (attr.value.type === 'TextNode') {
 
-    var namespace = getNamespace(attr.name) || null;
+    var namespace = getAttrNamespace(attr.name);
 
     this.opcode('setAttribute', [attr.name, attr.value.chars, namespace]);
   }

--- a/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
@@ -1,5 +1,6 @@
 import TemplateVisitor from "./template-visitor";
-import { processOpcodes, getNamespace } from "./utils";
+import { processOpcodes } from "./utils";
+import { getAttrNamespace } from "../htmlbars-util";
 import { forEach } from "../htmlbars-util/array-utils";
 import { isHelper } from "../htmlbars-syntax/utils";
 
@@ -173,7 +174,7 @@ HydrationOpcodeCompiler.prototype.component = function(component, childIndex, ch
 HydrationOpcodeCompiler.prototype.attribute = function(attr) {
   var value = attr.value;
   var escaped = true;
-  var namespace = getNamespace(attr.name) || null;
+  var namespace = getAttrNamespace(attr.name);
 
   // TODO: Introduce context specific AST nodes to avoid switching here.
   if (value.type === 'TextNode') {

--- a/packages/htmlbars-compiler/lib/utils.js
+++ b/packages/htmlbars-compiler/lib/utils.js
@@ -9,19 +9,3 @@ export function processOpcodes(compiler, opcodes) {
     }
   }
 }
-
-// ref http://dev.w3.org/html5/spec-LC/namespaces.html
-var defaultNamespaces = {
-  html: 'http://www.w3.org/1999/xhtml',
-  mathml: 'http://www.w3.org/1998/Math/MathML',
-  svg: 'http://www.w3.org/2000/svg',
-  xlink: 'http://www.w3.org/1999/xlink',
-  xml: 'http://www.w3.org/XML/1998/namespace'
-};
-
-export function getNamespace(attrName) {
-  var parts = attrName.split(':');
-  if (parts.length > 1) {
-    return defaultNamespaces[parts[0]];
-  }
-}

--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -102,6 +102,14 @@ test("Simple elements can have namespaced attributes", function() {
   equal(fragment.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
 });
 
+test("Simple elements can have bound namespaced attributes", function() {
+  var template = compile("<svg xlink:title={{title}}>content</svg>");
+  var fragment = template.render({title: 'svg-title'}, env);
+
+  equalTokens(fragment, '<svg xlink:title="svg-title">content</svg>');
+  equal(fragment.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
+});
+
 test("Simple elements can have an empty attribute", function() {
   var template = compile("<div class=''>content</div>");
   var fragment = template.render({}, env);

--- a/packages/htmlbars-util/lib/main.js
+++ b/packages/htmlbars-util/lib/main.js
@@ -1,7 +1,9 @@
 import SafeString from './htmlbars-util/safe-string';
 import { escapeExpression } from './htmlbars-util/handlebars/utils';
+import { getAttrNamespace } from './htmlbars-util/namespaces';
 
 export {
   SafeString,
-  escapeExpression
+  escapeExpression,
+  getAttrNamespace
 };

--- a/packages/htmlbars-util/lib/namespaces.js
+++ b/packages/htmlbars-util/lib/namespaces.js
@@ -1,0 +1,20 @@
+// ref http://dev.w3.org/html5/spec-LC/namespaces.html
+var defaultNamespaces = {
+  html: 'http://www.w3.org/1999/xhtml',
+  mathml: 'http://www.w3.org/1998/Math/MathML',
+  svg: 'http://www.w3.org/2000/svg',
+  xlink: 'http://www.w3.org/1999/xlink',
+  xml: 'http://www.w3.org/XML/1998/namespace'
+};
+
+export function getAttrNamespace(attrName) {
+  var namespace;
+
+  var colonIndex = attrName.indexOf(':');
+  if (colonIndex !== -1) {
+    var prefix = attrName.slice(0, colonIndex);
+    namespace = defaultNamespaces[prefix];
+  }
+
+  return namespace || null;
+}

--- a/packages/morph/lib/attr-morph.js
+++ b/packages/morph/lib/attr-morph.js
@@ -1,6 +1,7 @@
 import { sanitizeAttributeValue } from "./attr-morph/sanitize-attribute-value";
 import { isAttrRemovalValue, normalizeProperty } from "./dom-helper/prop";
 import { svgNamespace } from "./dom-helper/build-html-dom";
+import { getAttrNamespace } from "../htmlbars-util";
 
 function updateProperty(value) {
   this.domHelper.setPropertyStrict(this.element, this.attrName, value);
@@ -25,7 +26,7 @@ function updateAttributeNS(value) {
 function AttrMorph(element, attrName, domHelper, namespace) {
   this.element = element;
   this.domHelper = domHelper;
-  this.namespace = namespace || null;
+  this.namespace = namespace !== undefined ? namespace : getAttrNamespace(attrName);
   this.escaped = true;
 
   var normalizedAttrName = normalizeProperty(this.element, attrName);

--- a/packages/morph/tests/attr-morph-test.js
+++ b/packages/morph/tests/attr-morph-test.js
@@ -9,6 +9,13 @@ var domHelper = new DOMHelper();
 
 QUnit.module('morph: AttrMorph');
 
+test("detects attribute's namespace if it is not passed as an argument", function () {
+  var element = domHelper.createElement('div');
+  var morph = domHelper.createAttrMorph(element, 'xlink:href');
+  morph.setContent('#circle');
+  equal(element.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink', 'attribute has correct namespace');
+});
+
 test("can update a dom node", function(){
   var element = domHelper.createElement('div');
   var morph = domHelper.createAttrMorph(element, 'id');


### PR DESCRIPTION
This will allow `bind-attr` to work with namespaced attributes (no further changes needed), as well as eventually attributes bound via ember views (so long as the full attribute name is passed to `createAttrMorph`).  Also added a test for the bound case, which wasn't covered.