### PR TITLE
Allow numbers to be parsed as HTML in IE

### DIFF
--- a/packages/morph/lib/dom-helper/build-html-dom.js
+++ b/packages/morph/lib/dom-helper/build-html-dom.js
@@ -187,15 +187,17 @@ if (tagNamesRequiringInnerHTMLFix || movesWhitespace) {
     // script tags without any whitespace for easier processing later.
     var spacesBefore = [];
     var spacesAfter = [];
-    html = html.replace(/(\s*)(<script)/g, function(match, spaces, tag) {
-      spacesBefore.push(spaces);
-      return tag;
-    });
+    if (typeof html === 'string') {
+      html = html.replace(/(\s*)(<script)/g, function(match, spaces, tag) {
+        spacesBefore.push(spaces);
+        return tag;
+      });
 
-    html = html.replace(/(<\/script>)(\s*)/g, function(match, tag, spaces) {
-      spacesAfter.push(spaces);
-      return tag;
-    });
+      html = html.replace(/(<\/script>)(\s*)/g, function(match, tag, spaces) {
+        spacesAfter.push(spaces);
+        return tag;
+      });
+    }
 
     // Fetch nodes
     var nodes;

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -373,6 +373,13 @@ test('#parseHTML with retains whitespace after script', function(){
   equalHTML(nodes, '<span>hello</span><script id="first"></script><span><script></script> kwoop</span>');
 });
 
+test('#parseHTML of number', function(){
+  var div = document.createElement('div');
+  var nodes = dom.parseHTML(5, div);
+  equal(nodes[0].data, '5');
+  equalHTML(nodes, '5');
+});
+
 test('#cloneNode shallow', function(){
   var divElement = document.createElement('div');
 

--- a/packages/morph/tests/morph-test.js
+++ b/packages/morph/tests/morph-test.js
@@ -145,6 +145,10 @@ function morphTests(factory) {
     html = startHTML+'oh hai'+endHTML;
     equalHTML(newFrag, html);
 
+    morph.setContent(5);
+    html = startHTML+'5'+endHTML;
+    equalHTML(newFrag, html);
+
     morph.setContent('oh bai');
     html = startHTML+'oh bai'+endHTML;
     equalHTML(newFrag, html);


### PR DESCRIPTION
I some cases (like select tests in Ember), numbers may be passed to `parseHTML`. This fixes that code path for IE <10.