### PR TITLE
Include line number in error thrown for unclosed html element (#254)

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -941,6 +941,17 @@ QUnit.module("HTML-based compiler (invalid HTML errors)", {
   setup: commonSetup
 });
 
+test("A helpful error message is provided for unclosed elements", function() {
+  expect(2);
+
+  QUnit.throws(function() {
+    compile('\n<div class="my-div" \n foo={{bar}}>\n<span>\n</span>\n');
+  }, /Unclosed element `div` \(on line 2\)\./);
+  QUnit.throws(function() {
+    compile('\n<div class="my-div">\n<span>\n');
+  }, /Unclosed element `span` \(on line 3\)\./);
+});
+
 test("A helpful error message is provided for unmatched end tags", function() {
   expect(2);
 

--- a/packages/htmlbars-syntax/lib/node-handlers.js
+++ b/packages/htmlbars-syntax/lib/node-handlers.js
@@ -27,7 +27,7 @@ var nodeHandlers = {
     // Ensure that that the element stack is balanced properly.
     var poppedNode = this.elementStack.pop();
     if (poppedNode !== node) {
-      throw new Error("Unclosed element: " + poppedNode.tag);
+      throw new Error("Unclosed element `" + poppedNode.tag + "` (on line " + poppedNode.loc.start.line + ").");
     }
 
     return node;


### PR DESCRIPTION
For https://github.com/tildeio/htmlbars/issues/254.

Includes tests for both the basic case and one with two unclosed elements.  The implementation will always throw on the last unclosed one left.  So the second test is currently testing an implementation detail.  I'd be open to removing it or modifying it to only check that some error is thrown but be agnostic as to which element it's about.