### PR TITLE
removeAttribute fix for IE <11 and svg

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -30,6 +30,13 @@ var ignoresCheckedAttribute = doc && (function(document){
   return !clonedElement.checked;
 })(doc);
 
+var canRemoveSvgViewBoxAttribute = doc && (doc.createElementNS ? (function(document){
+  var element = document.createElementNS(svgNamespace, 'svg');
+  element.setAttribute('viewBox', '0 0 100 100');
+  element.removeAttribute('viewBox');
+  return !element.getAttribute('viewBox');
+})(doc) : true);
+
 // This is not the namespace of the element, but of
 // the elements inside that elements.
 function interiorNamespace(element){
@@ -154,9 +161,23 @@ prototype.setAttribute = function(element, name, value) {
   element.setAttribute(name, String(value));
 };
 
-prototype.removeAttribute = function(element, name) {
-  element.removeAttribute(name);
+prototype.setAttributeNS = function(element, namespace, name, value) {
+  element.setAttributeNS(namespace, name, String(value));
 };
+
+if (canRemoveSvgViewBoxAttribute){
+  prototype.removeAttribute = function(element, name) {
+    element.removeAttribute(name);
+  };
+} else {
+  prototype.removeAttribute = function(element, name) {
+    if (element.tagName === 'svg' && name === 'viewBox') {
+      element.setAttribute(name, null);
+    } else {
+      element.removeAttribute(name);
+    }
+  };
+}
 
 prototype.setPropertyStrict = function(element, name, value) {
   element[name] = value;

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -118,6 +118,16 @@ test('#removeAttribute', function(){
   equalHTML(node, '<div></div>', 'attribute was removed');
 });
 
+test('#removeAttribute of SVG', function(){
+  dom.setNamespace(svgNamespace);
+  var node = dom.createElement('svg');
+  dom.setAttribute(node, 'viewBox', '0 0 100 100');
+  equalHTML(node, '<svg viewBox="0 0 100 100"></svg>', 'precond - attribute exists');
+
+  dom.removeAttribute(node, 'viewBox');
+  equalHTML(node, '<svg></svg>', 'attribute was removed');
+});
+
 test('#setProperty', function(){
   var node = dom.createElement('div');
   dom.setProperty(node, 'id', 'super-tag');


### PR DESCRIPTION
Fixes #251

Old IE cannot remove svg attributes. Create a slow path for it.