### PR TITLE
Use linked list walking for childAtIndex

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,6 +5,7 @@
     "test": true,
     "expect": true,
     "equal": true,
+    "strictEqual": true,
     "deepEqual": true,
     "ok": true
   },

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -40,11 +40,19 @@ test('#childAtIndex', function() {
   var child1 = dom.createElement('p');
   var child2 = dom.createElement('img');
 
+  strictEqual(dom.childAtIndex(node, 0), null);
+  strictEqual(dom.childAtIndex(node, 1), null);
+  strictEqual(dom.childAtIndex(node, 2), null);
+
   dom.appendChild(node, child1);
-  equal(dom.childAtIndex(node, 0).tagName, 'P');
+  strictEqual(dom.childAtIndex(node, 0).tagName, 'P');
+  strictEqual(dom.childAtIndex(node, 1), null);
+  strictEqual(dom.childAtIndex(node, 2), null);
 
   dom.insertBefore(node, child2, child1);
-  equal(dom.childAtIndex(node, 0).tagName, 'IMG');
+  strictEqual(dom.childAtIndex(node, 0).tagName, 'IMG');
+  strictEqual(dom.childAtIndex(node, 1).tagName, 'P');
+  strictEqual(dom.childAtIndex(node, 2), null);
 });
 
 test('#appendText adds text', function(){


### PR DESCRIPTION
This implementation entirely removes the dependency on an element’s
`childNodes` live collection. This is beneficial because:

1. IE8 required a bounds check that relied on childNodes.length, which
   in turn meant we had to implement an array-backed live collection of childNodes in simple-dom
   which is slow and error-prone, and
3. The browser just uses a linked list anyway and we were forcing *it*
   to materialize and keep updated a live collection until GC time.

This implementation just does what the browser would do anyway, while
making our simple-dom implementation actually, well, simple, and
includes notes about all of this for future fearless adventurers who
find themselves in this area of the code.