### PR TITLE
Update ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,7 +61,7 @@ The above vanilla HB AST looks something like:
       Mustache: `onclick` params=[`"like"`]
       Content: '>Like</button> </p>'
 
-See [parser.js](packages/htmlbars-compiler/lib/parser.js)
+See [parser.js](packages/htmlbars-syntax/lib/parser.js)
 
 ### 2. Convert to HTMLBars AST
 
@@ -86,7 +86,7 @@ something like:
       Element tag='button' helpers=[Mustache(`onclick "like"`)]
         "Like"
 
-See [parser.js](packages/htmlbars-compiler/lib/parser.js) and 
+See [parser.js](packages/htmlbars-syntax/lib/parser.js) and 
 [ast.js](packages/htmlbars-compiler/lib/ast.js).
 
 ### 3. Build document fragment generator from HTMLbars AST

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,7 +148,7 @@ build up this fragment (i.e. the `createDocumentFragment`, `createElement`,
 `createTextNode`, etc., code from above). HTMLbars accomplishes this in
 two passes (on the compile side): 
 
-1. In [fragment-opcode-compiler.js](packages/htmlbars-compiler/lib/compiler/fragment-opcode-compiler.js),
+1. In [fragment-opcode-compiler.js](packages/htmlbars-compiler/lib/fragment-opcode-compiler.js),
    the HTMLbars AST is recursively walked and a flattened 
    array of opcodes (used in step 2) is generated. 
    The intent of this phase is to flatten the recursive structure of the 


### PR DESCRIPTION
fix broken links to parser.js
[parser.js](packages/htmlbars-syntax/lib/parser.js)

ast.js link also seems to be broken, but not sure where it is suppose to go.