### PR TITLE
Add hook for extracting protocol from URLs

### DIFF
--- a/packages/morph/lib/dom-helper.js
+++ b/packages/morph/lib/dom-helper.js
@@ -403,4 +403,16 @@ prototype.parseHTML = function(html, contextualElement) {
   }
 };
 
+var parsingNode;
+
+// Used to determine whether a URL needs to be sanitized.
+prototype.protocolForURL = function(url) {
+  if (!parsingNode) {
+    parsingNode = this.document.createElement('a');
+  }
+
+  parsingNode.href = url;
+  return parsingNode.protocol;
+};
+
 export default DOMHelper;

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -377,9 +377,9 @@ test('#protocolForURL', function() {
   equal(protocol, "http:");
 
   // Inherit protocol from document if unparseable
-  protocol = dom.protocolForURL("   javascript  :lulzhacked()");
+  protocol = dom.protocolForURL("   javascript:lulzhacked()");
   /*jshint scripturl:true*/
-  equal(protocol, "http:");
+  equal(protocol, "javascript:");
 });
 
 test('#cloneNode shallow', function(){

--- a/packages/morph/tests/dom-helper-test.js
+++ b/packages/morph/tests/dom-helper-test.js
@@ -372,6 +372,16 @@ test('#parseHTML of number', function(){
   equalHTML(nodes, '5');
 });
 
+test('#protocolForURL', function() {
+  var protocol = dom.protocolForURL("http://www.emberjs.com");
+  equal(protocol, "http:");
+
+  // Inherit protocol from document if unparseable
+  protocol = dom.protocolForURL("   javascript  :lulzhacked()");
+  /*jshint scripturl:true*/
+  equal(protocol, "http:");
+});
+
 test('#cloneNode shallow', function(){
   var divElement = document.createElement('div');
 


### PR DESCRIPTION
In order to sanitize potentially dangerous URLs that contain executable
behavior (e.g. “javascript:” URLs), we need to determine the protocol.

Unfortunately, URL parsing is notoriously error-prone, so we want to use
the host environment’s native functionality such that the protocol we
report is the same as what it will act upon.

In this case, we expose a `protocolForURL` hook that uses a generated
`<a>` element to set its `href` and check the resulting `protocol`. A
Node.js implementation could fall back to using the `url` package that
is included in the standard library.