### PR TITLE
Pass dom helper to sanitizer

### DIFF
--- a/packages/morph-attr/lib/main.js
+++ b/packages/morph-attr/lib/main.js
@@ -46,7 +46,7 @@ function AttrMorph(element, attrName, domHelper, namespace) {
 
 AttrMorph.prototype.setContent = function (value) {
   if (this.escaped) {
-    var sanitized = sanitizeAttributeValue(this.element, this.attrName, value);
+    var sanitized = sanitizeAttributeValue(this.domHelper, this.element, this.attrName, value);
     this._update(sanitized, this.namespace);
   } else {
     this._update(value, this.namespace);
@@ -54,3 +54,5 @@ AttrMorph.prototype.setContent = function (value) {
 };
 
 export default AttrMorph;
+
+export { sanitizeAttributeValue };

--- a/packages/morph-attr/lib/sanitize-attribute-value.js
+++ b/packages/morph-attr/lib/sanitize-attribute-value.js
@@ -1,6 +1,5 @@
 /* jshint scripturl:true */
 
-var parsingNode;
 var badProtocols = {
   'javascript:': true,
   'vbscript:': true
@@ -20,12 +19,8 @@ export var badAttributes = {
   'background': true
 };
 
-export function sanitizeAttributeValue(element, attribute, value) {
+export function sanitizeAttributeValue(dom, element, attribute, value) {
   var tagName;
-
-  if (!parsingNode) {
-    parsingNode = document.createElement('a');
-  }
 
   if (!element) {
     tagName = null;
@@ -38,9 +33,8 @@ export function sanitizeAttributeValue(element, attribute, value) {
   }
 
   if ((tagName === null || badTags[tagName]) && badAttributes[attribute]) {
-    parsingNode.href = value;
-
-    if (badProtocols[parsingNode.protocol] === true) {
+    var protocol = dom.protocolForURL(value);
+    if (badProtocols[protocol] === true) {
       return 'unsafe:' + value;
     }
   }

--- a/packages/morph-attr/tests/attr-morph/sanitize-attribute-value-test.js
+++ b/packages/morph-attr/tests/attr-morph/sanitize-attribute-value-test.js
@@ -1,6 +1,10 @@
 import { sanitizeAttributeValue } from "morph-attr/sanitize-attribute-value";
 import SafeString from "htmlbars-util/safe-string";
 
+import DOMHelper from "../../dom-helper";
+
+var domHelper = new DOMHelper();
+
 QUnit.module('sanitizeAttributeValue(null, "href")');
 
 var goodProtocols = [ 'https', 'http', 'ftp', 'tel', 'file'];
@@ -14,7 +18,7 @@ function buildProtocolTest(protocol) {
     expect(1);
 
     var expected = protocol + '://foo.com';
-    var actual = sanitizeAttributeValue(null, 'href', expected);
+    var actual = sanitizeAttributeValue(domHelper, null, 'href', expected);
 
     equal(actual, expected, 'protocol not escaped');
   });
@@ -26,7 +30,7 @@ test('blocks javascript: protocol', function() {
   expect(1);
 
   var expected = 'javascript:alert("foo")';
-  var actual = sanitizeAttributeValue(null, 'href', expected);
+  var actual = sanitizeAttributeValue(domHelper, null, 'href', expected);
 
   equal(actual, 'unsafe:' + expected, 'protocol escaped');
 });
@@ -37,7 +41,7 @@ test('blocks blacklisted protocols', function() {
   expect(1);
 
   var expected = 'javascript:alert("foo")';
-  var actual = sanitizeAttributeValue(null, 'href', expected);
+  var actual = sanitizeAttributeValue(domHelper, null, 'href', expected);
 
   equal(actual, 'unsafe:' + expected, 'protocol escaped');
 });
@@ -48,7 +52,7 @@ test('does not block SafeStrings', function() {
   expect(1);
 
   var expected = 'javascript:alert("foo")';
-  var actual = sanitizeAttributeValue(null, 'href', new SafeString(expected));
+  var actual = sanitizeAttributeValue(domHelper, null, 'href', new SafeString(expected));
 
   equal(actual, expected, 'protocol unescaped');
 });


### PR DESCRIPTION
Update the logic to be more like Ember https://github.com/emberjs/ember.js/blob/04463cf3f65625fbbdc8b09efaf402a43dca4de0/packages/ember-views/lib/system/sanitize_attribute_value.js#L22 which means we should soon be able to drop the Ember version.

Also exposes the sanitize function on morph-attr main.