### PR TITLE
Always build fragment

### DIFF
--- a/packages/dom-helper/lib/main.js
+++ b/packages/dom-helper/lib/main.js
@@ -387,8 +387,10 @@ prototype.appendMorph = function(element, contextualElement) {
 };
 
 prototype.parseHTML = function(html, contextualElement) {
+  var childNodes;
+
   if (interiorNamespace(contextualElement) === svgNamespace) {
-    return buildSVGDOM(html, this);
+    childNodes = buildSVGDOM(html, this);
   } else {
     var nodes = buildHTMLDOM(html, contextualElement, this);
     if (detectOmittedStartTag(html, contextualElement)) {
@@ -396,11 +398,26 @@ prototype.parseHTML = function(html, contextualElement) {
       while (node && node.nodeType !== 1) {
         node = node.nextSibling;
       }
-      return node.childNodes;
+      childNodes = node.childNodes;
     } else {
-      return nodes;
+      childNodes = nodes;
     }
   }
+
+  // Copy node list to a fragment.
+  var fragment = this.document.createDocumentFragment();
+
+  if (childNodes && childNodes.length > 0) {
+    var currentNode = childNodes[0];
+
+    while (currentNode) {
+      var tempNode = currentNode;
+      currentNode = currentNode.nextSibling;
+      fragment.appendChild(tempNode);
+    }
+  }
+
+  return fragment;
 };
 
 var parsingNode;

--- a/packages/dom-helper/tests/dom-helper-test.js
+++ b/packages/dom-helper/tests/dom-helper-test.js
@@ -270,7 +270,7 @@ test('#parseHTML combinations', function(){
     expectedTagName = parsingCombinations[p][2];
 
     contextElement = document.createElement(contextTag);
-    nodes = dom.parseHTML(content, contextElement);
+    nodes = dom.parseHTML(content, contextElement).childNodes;
     equal(
       nodes[0].tagName, expectedTagName,
       '#parseHTML of '+content+' returns a '+expectedTagName+' inside a '+contextTag+' context' );
@@ -279,7 +279,7 @@ test('#parseHTML combinations', function(){
 
 test('#parseHTML of script then tr inside table context wraps the tr in a tbody', function(){
   var tableElement = document.createElement('table'),
-      nodes = dom.parseHTML('<script></script><tr><td>Yo</td></tr>', tableElement);
+      nodes = dom.parseHTML('<script></script><tr><td>Yo</td></tr>', tableElement).childNodes;
   // The HTML spec suggests the first item must be the child of
   // the omittable start tag. Here script is the first child, so no-go.
   equal(nodes.length, 2, 'Leading script tag corrupts');
@@ -289,7 +289,7 @@ test('#parseHTML of script then tr inside table context wraps the tr in a tbody'
 
 test('#parseHTML of select allows the initial implicit option selection to remain', function(){
   var div = document.createElement('div');
-  var select = dom.parseHTML('<select><option></option></select>', div)[0];
+  var select = dom.parseHTML('<select><option></option></select>', div).childNodes[0];
 
   ok(select.childNodes[0].selected, 'first element is selected');
 });
@@ -299,7 +299,7 @@ test('#parseHTML of options removes an implicit selection', function(){
   var options = dom.parseHTML(
     '<option value="1"></option><option value="2"></option>',
     select
-  );
+  ).childNodes;
 
   ok(!options[0].selected, 'first element is not selected');
   ok(!options[1].selected, 'second element is not selected');
@@ -310,7 +310,7 @@ test('#parseHTML of options leaves an explicit first selection', function(){
   var options = dom.parseHTML(
     '<option value="1" selected></option><option value="2"></option>',
     select
-  );
+  ).childNodes;
 
   ok(options[0].selected, 'first element is selected');
   ok(!options[1].selected, 'second element is not selected');
@@ -321,7 +321,7 @@ test('#parseHTML of options leaves an explicit second selection', function(){
   var options = dom.parseHTML(
     '<option value="1"></option><option value="2" selected="selected"></option>',
     select
-  );
+  ).childNodes;
 
   ok(!options[0].selected, 'first element is not selected');
   ok(options[1].selected, 'second element is selected');
@@ -329,7 +329,7 @@ test('#parseHTML of options leaves an explicit second selection', function(){
 
 test('#parseHTML of script then tr inside tbody context', function(){
   var tbodyElement = document.createElement('tbody'),
-      nodes = dom.parseHTML('<script></script><tr><td>Yo</td></tr>', tbodyElement);
+      nodes = dom.parseHTML('<script></script><tr><td>Yo</td></tr>', tbodyElement).childNodes;
   equal(nodes.length, 2, 'Leading script tag corrupts');
   equal(nodes[0].tagName, 'SCRIPT');
   equal(nodes[1].tagName, 'TR');
@@ -337,7 +337,7 @@ test('#parseHTML of script then tr inside tbody context', function(){
 
 test('#parseHTML with retains whitespace', function(){
   var div = document.createElement('div');
-  var nodes = dom.parseHTML('leading<script id="first"></script> <script id="second"></script><div><script></script> <script></script>, indeed.</div>', div);
+  var nodes = dom.parseHTML('leading<script id="first"></script> <script id="second"></script><div><script></script> <script></script>, indeed.</div>', div).childNodes;
   equal(nodes[0].data, 'leading');
   equal(nodes[1].tagName, 'SCRIPT');
   equal(nodes[2].data, ' ');
@@ -351,14 +351,14 @@ test('#parseHTML with retains whitespace', function(){
 
 test('#parseHTML with retains whitespace of top element', function(){
   var div = document.createElement('div');
-  var nodes = dom.parseHTML('<span>hello <script id="first"></script> yeah</span>', div);
+  var nodes = dom.parseHTML('<span>hello <script id="first"></script> yeah</span>', div).childNodes;
   equal(nodes[0].tagName, 'SPAN');
   equalHTML(nodes, '<span>hello <script id="first"></script> yeah</span>');
 });
 
 test('#parseHTML with retains whitespace after script', function(){
   var div = document.createElement('div');
-  var nodes = dom.parseHTML('<span>hello</span><script id="first"></script><span><script></script> kwoop</span>', div);
+  var nodes = dom.parseHTML('<span>hello</span><script id="first"></script><span><script></script> kwoop</span>', div).childNodes;
   equal(nodes[0].tagName, 'SPAN');
   equal(nodes[1].tagName, 'SCRIPT');
   equal(nodes[2].tagName, 'SPAN');
@@ -367,7 +367,7 @@ test('#parseHTML with retains whitespace after script', function(){
 
 test('#parseHTML of number', function(){
   var div = document.createElement('div');
-  var nodes = dom.parseHTML(5, div);
+  var nodes = dom.parseHTML(5, div).childNodes;
   equal(nodes[0].data, '5');
   equalHTML(nodes, '5');
 });
@@ -552,7 +552,7 @@ for (i=0;i<foreignNamespaces.length;i++) {
   test('#parseHTML of div with '+foreignNamespace, function(){
     dom.setNamespace(xhtmlNamespace);
     var foreignObject = document.createElementNS(svgNamespace, foreignNamespace),
-        nodes = dom.parseHTML('<div></div>', foreignObject);
+        nodes = dom.parseHTML('<div></div>', foreignObject).childNodes;
     equal(nodes[0].tagName, 'DIV');
     equal(nodes[0].namespaceURI, xhtmlNamespace);
   }); // jshint ignore:line
@@ -561,7 +561,7 @@ for (i=0;i<foreignNamespaces.length;i++) {
 test('#parseHTML of path with svg contextual element', function(){
   dom.setNamespace(svgNamespace);
   var svgElement = document.createElementNS(svgNamespace, 'svg'),
-      nodes = dom.parseHTML('<path></path>', svgElement);
+      nodes = dom.parseHTML('<path></path>', svgElement).childNodes;
   equal(nodes[0].tagName, 'path');
   equal(nodes[0].namespaceURI, svgNamespace);
 });
@@ -569,7 +569,7 @@ test('#parseHTML of path with svg contextual element', function(){
 test('#parseHTML of stop with linearGradient contextual element', function(){
   dom.setNamespace(svgNamespace);
   var svgElement = document.createElementNS(svgNamespace, 'linearGradient'),
-      nodes = dom.parseHTML('<stop />', svgElement);
+      nodes = dom.parseHTML('<stop />', svgElement).childNodes;
   equal(nodes[0].tagName, 'stop');
   equal(nodes[0].namespaceURI, svgNamespace);
 });

--- a/packages/htmlbars-compiler/lib/fragment-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/fragment-opcode-compiler.js
@@ -22,14 +22,14 @@ FragmentOpcodeCompiler.prototype.opcode = function(type, params) {
   this.opcodes.push([type, params]);
 };
 
-FragmentOpcodeCompiler.prototype.text = function(text, childIndex, childCount, isSingleRoot) {
+FragmentOpcodeCompiler.prototype.text = function(text) {
   this.opcode('createText', [text.chars]);
-  if (!isSingleRoot) { this.opcode('appendChild'); }
+  this.opcode('appendChild');
 };
 
-FragmentOpcodeCompiler.prototype.comment = function(comment, childIndex, childCount, isSingleRoot) {
+FragmentOpcodeCompiler.prototype.comment = function(comment) {
   this.opcode('createComment', [comment.value]);
-  if (!isSingleRoot) { this.opcode('appendChild'); }
+  this.opcode('appendChild');
 };
 
 FragmentOpcodeCompiler.prototype.openElement = function(element) {
@@ -37,18 +37,16 @@ FragmentOpcodeCompiler.prototype.openElement = function(element) {
   forEach(element.attributes, this.attribute, this);
 };
 
-FragmentOpcodeCompiler.prototype.closeElement = function(element, childIndex, childCount, isSingleRoot) {
-  if (!isSingleRoot) { this.opcode('appendChild'); }
+FragmentOpcodeCompiler.prototype.closeElement = function() {
+  this.opcode('appendChild');
 };
 
-FragmentOpcodeCompiler.prototype.startProgram = function(program) {
+FragmentOpcodeCompiler.prototype.startProgram = function() {
   this.opcodes.length = 0;
-  if (program.body.length !== 1) {
-    this.opcode('createFragment');
-  }
+  this.opcode('createFragment');
 };
 
-FragmentOpcodeCompiler.prototype.endProgram = function(/* program */) {
+FragmentOpcodeCompiler.prototype.endProgram = function() {
   this.opcode('returnNode');
 };
 
@@ -60,9 +58,7 @@ FragmentOpcodeCompiler.prototype.block = function () {};
 
 FragmentOpcodeCompiler.prototype.attribute = function(attr) {
   if (attr.value.type === 'TextNode') {
-
     var namespace = getAttrNamespace(attr.name);
-
     this.opcode('setAttribute', [attr.name, attr.value.chars, namespace]);
   }
 };

--- a/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
@@ -73,33 +73,32 @@ HydrationOpcodeCompiler.prototype.startProgram = function(program, c, blankChild
   }
 };
 
-HydrationOpcodeCompiler.prototype.endProgram = function(/* program */) {
+HydrationOpcodeCompiler.prototype.endProgram = function() {
   distributeMorphs(this.morphs, this.opcodes);
 };
 
-HydrationOpcodeCompiler.prototype.text = function(/* string, pos, len */) {
+HydrationOpcodeCompiler.prototype.text = function() {
   ++this.currentDOMChildIndex;
 };
 
-HydrationOpcodeCompiler.prototype.comment = function(/* string, pos, len */) {
+HydrationOpcodeCompiler.prototype.comment = function() {
   ++this.currentDOMChildIndex;
 };
 
-HydrationOpcodeCompiler.prototype.openElement = function(element, pos, len, isSingleRoot, mustacheCount, blankChildTextNodes) {
+HydrationOpcodeCompiler.prototype.openElement = function(element, pos, len, mustacheCount, blankChildTextNodes) {
   distributeMorphs(this.morphs, this.opcodes);
   ++this.currentDOMChildIndex;
 
   this.element = this.currentDOMChildIndex;
 
-  if (!isSingleRoot) {
-    this.opcode('consumeParent', this.currentDOMChildIndex);
+  this.opcode('consumeParent', this.currentDOMChildIndex);
 
-    // If our parent reference will be used more than once, cache its reference.
-    if (mustacheCount > 1) {
-      this.opcode('shareElement', ++this.elementNum);
-      this.element = null; // Set element to null so we don't cache it twice
-    }
+  // If our parent reference will be used more than once, cache its reference.
+  if (mustacheCount > 1) {
+    this.opcode('shareElement', ++this.elementNum);
+    this.element = null; // Set element to null so we don't cache it twice
   }
+
   var isElementChecked = detectIsElementChecked(element);
   if (blankChildTextNodes.length > 0 || isElementChecked) {
     this.opcode( 'repairClonedNode',
@@ -114,9 +113,9 @@ HydrationOpcodeCompiler.prototype.openElement = function(element, pos, len, isSi
   forEach(element.helpers, this.elementHelper, this);
 };
 
-HydrationOpcodeCompiler.prototype.closeElement = function(element, pos, len, isSingleRoot) {
+HydrationOpcodeCompiler.prototype.closeElement = function() {
   distributeMorphs(this.morphs, this.opcodes);
-  if (!isSingleRoot) { this.opcode('popParent'); }
+  this.opcode('popParent');
   this.currentDOMChildIndex = this.paths.pop();
 };
 

--- a/packages/htmlbars-compiler/lib/template-visitor.js
+++ b/packages/htmlbars-compiler/lib/template-visitor.js
@@ -105,7 +105,6 @@ TemplateVisitor.prototype.Program = function(program) {
 TemplateVisitor.prototype.ElementNode = function(element) {
   var parentFrame = this.getCurrentFrame();
   var elementFrame = this.pushFrame();
-  var parentNode = parentFrame.parentNode;
 
   elementFrame.parentNode = element;
   elementFrame.children = element.children;
@@ -116,8 +115,7 @@ TemplateVisitor.prototype.ElementNode = function(element) {
   var actionArgs = [
     element,
     parentFrame.childIndex,
-    parentFrame.childCount,
-    parentNode.type === 'Program' && parentFrame.childCount === 1
+    parentFrame.childCount
   ];
 
   elementFrame.actions.push(['closeElement', actionArgs]);
@@ -149,11 +147,10 @@ TemplateVisitor.prototype.AttrNode = function(attr) {
 
 TemplateVisitor.prototype.TextNode = function(text) {
   var frame = this.getCurrentFrame();
-  var isSingleRoot = frame.parentNode.type === 'Program' && frame.childCount === 1;
   if (text.chars === '') {
     frame.blankChildTextNodes.push(domIndexOf(frame.children, text));
   }
-  frame.actions.push(['text', [text, frame.childIndex, frame.childCount, isSingleRoot]]);
+  frame.actions.push(['text', [text, frame.childIndex, frame.childCount]]);
 };
 
 TemplateVisitor.prototype.BlockStatement = function(node) {
@@ -184,9 +181,7 @@ TemplateVisitor.prototype.PartialStatement = function(node) {
 
 TemplateVisitor.prototype.CommentStatement = function(text) {
   var frame = this.getCurrentFrame();
-  var isSingleRoot = frame.parentNode.type === 'Program' && frame.childCount === 1;
-
-  frame.actions.push(['comment', [text, frame.childIndex, frame.childCount, isSingleRoot]]);
+  frame.actions.push(['comment', [text, frame.childIndex, frame.childCount]]);
 };
 
 TemplateVisitor.prototype.MustacheStatement = function(mustache) {

--- a/packages/htmlbars-compiler/tests/fragment-test.js
+++ b/packages/htmlbars-compiler/tests/fragment-test.js
@@ -43,54 +43,54 @@ QUnit.module('fragment');
 
 test('compiles a fragment', function () {
   var ast = preprocess("<div>{{foo}} bar {{baz}}</div>");
-  var fragment = fragmentFor(ast);
+  var divNode = fragmentFor(ast).firstChild;
 
-  equalHTML(fragment, "<div> bar </div>");
+  equalHTML(divNode, "<div> bar </div>");
 });
 
 if (document && document.createElementNS) {
   test('compiles an svg fragment', function () {
     var ast = preprocess("<div><svg><circle/><foreignObject><span></span></foreignObject></svg></div>");
-    var fragment = fragmentFor(ast);
+    var divNode = fragmentFor(ast).firstChild;
 
-    equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+    equal( divNode.childNodes[0].namespaceURI, svgNamespace,
            'svg has the right namespace' );
-    equal( fragment.childNodes[0].childNodes[0].namespaceURI, svgNamespace,
+    equal( divNode.childNodes[0].childNodes[0].namespaceURI, svgNamespace,
            'circle has the right namespace' );
-    equal( fragment.childNodes[0].childNodes[1].namespaceURI, svgNamespace,
+    equal( divNode.childNodes[0].childNodes[1].namespaceURI, svgNamespace,
            'foreignObject has the right namespace' );
-    equal( fragment.childNodes[0].childNodes[1].childNodes[0].namespaceURI, xhtmlNamespace,
+    equal( divNode.childNodes[0].childNodes[1].childNodes[0].namespaceURI, xhtmlNamespace,
            'span has the right namespace' );
   });
 }
   
 test('compiles an svg element with classes', function () {
   var ast = preprocess('<svg class="red right hand"></svg>');
-  var fragment = fragmentFor(ast);
+  var svgNode = fragmentFor(ast).firstChild;
 
-  equal(fragment.getAttribute('class'), 'red right hand');
+  equal(svgNode.getAttribute('class'), 'red right hand');
 });
 
 if (document && document.createElementNS) {
   test('compiles an svg element with proper namespace', function () {
     var ast = preprocess('<svg><use xlink:title="nice-title"></use></svg>');
-    var fragment = fragmentFor(ast);
+    var svgNode = fragmentFor(ast).firstChild;
 
-    equal(fragment.childNodes[0].getAttributeNS('http://www.w3.org/1999/xlink', 'title'), 'nice-title');
-    equal(fragment.childNodes[0].attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
-    equal(fragment.childNodes[0].attributes[0].name, 'xlink:title');
-    equal(fragment.childNodes[0].attributes[0].localName, 'title');
-    equal(fragment.childNodes[0].attributes[0].value, 'nice-title');
+    equal(svgNode.childNodes[0].getAttributeNS('http://www.w3.org/1999/xlink', 'title'), 'nice-title');
+    equal(svgNode.childNodes[0].attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
+    equal(svgNode.childNodes[0].attributes[0].name, 'xlink:title');
+    equal(svgNode.childNodes[0].attributes[0].localName, 'title');
+    equal(svgNode.childNodes[0].attributes[0].value, 'nice-title');
   });
 
 }
   
 test('converts entities to their char/string equivalent', function () {
   var ast = preprocess("<div title=\"&quot;Foo &amp; Bar&quot;\">lol &lt; &#60;&#x3c; &#x3C; &LT; &NotGreaterFullEqual; &Borksnorlax;</div>");
-  var fragment = fragmentFor(ast);
+  var divNode = fragmentFor(ast).firstChild;
 
-  equal(fragment.getAttribute('title'), '"Foo & Bar"');
-  equal(getTextContent(fragment), "lol < << < < ≧̸ &Borksnorlax;");
+  equal(divNode.getAttribute('title'), '"Foo & Bar"');
+  equal(getTextContent(divNode), "lol < << < < ≧̸ &Borksnorlax;");
 });
 
 test('hydrates a fragment with morph mustaches', function () {
@@ -124,7 +124,7 @@ test('hydrates a fragment with morph mustaches', function () {
 
   var foo = contentResolves[0];
   equal(foo.morph.escaped, true, 'morph escaped');
-  equal(foo.morph.parent(), fragment, 'morph parent');
+  equal(foo.morph.parent(), fragment.firstChild, 'morph parent');
   equal(foo.context, context, 'context');
   equal(foo.path, 'foo', 'path');
   deepEqual(foo.params, ["bar",3,"BLAH", true], 'params');
@@ -132,7 +132,7 @@ test('hydrates a fragment with morph mustaches', function () {
 
   var baz = contentResolves[1];
   equal(baz.morph.escaped, true, 'morph escaped');
-  equal(baz.morph.parent(), fragment, 'morph parent');
+  equal(baz.morph.parent(), fragment.firstChild, 'morph parent');
   equal(baz.context, context, 'context');
   equal(baz.path, 'baz', 'path');
 

--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -136,49 +136,46 @@ test("Simple elements can have an empty attribute", function() {
 
 test("presence of `disabled` attribute without value marks as disabled", function() {
   var template = compile('<input disabled>');
-  var fragment = template.render({}, env);
+  var inputNode = template.render({}, env).firstChild;
 
-  ok(fragment.disabled, 'disabled without value set as property is true');
+  ok(inputNode.disabled, 'disabled without value set as property is true');
 });
 
 test("Null quoted attribute value calls toString on the value", function() {
   var template = compile('<input disabled="{{isDisabled}}">');
-  var fragment = template.render({isDisabled: null}, env);
+  var inputNode = template.render({isDisabled: null}, env).firstChild;
 
-  ok(fragment.disabled, 'string of "null" set as property is true');
+  ok(inputNode.disabled, 'string of "null" set as property is true');
 });
 
 test("Null unquoted attribute value removes that attribute", function() {
-
   var template = compile('<input disabled={{isDisabled}}>');
-  var fragment = template.render({isDisabled: null}, env);
+  var inputNode = template.render({isDisabled: null}, env).firstChild;
 
-  equalTokens(fragment, '<input>');
+  equalTokens(inputNode, '<input>');
 });
 
 test("unquoted attribute string is just that", function() {
-
   var template = compile('<input value=funstuff>');
-  var fragment = template.render({}, env);
+  var inputNode = template.render({}, env).firstChild;
 
-  equal(fragment.tagName, 'INPUT', 'input tag');
-  equal(fragment.value, 'funstuff', 'value is set as property');
+  equal(inputNode.tagName, 'INPUT', 'input tag');
+  equal(inputNode.value, 'funstuff', 'value is set as property');
 });
 
 test("unquoted attribute expression is string", function() {
-
   var template = compile('<input value={{funstuff}}>');
-  var fragment = template.render({funstuff: "oh my"}, env);
+  var inputNode = template.render({funstuff: "oh my"}, env).firstChild;
 
-  equal(fragment.tagName, 'INPUT', 'input tag');
-  equal(fragment.value, 'oh my', 'string is set to property');
+  equal(inputNode.tagName, 'INPUT', 'input tag');
+  equal(inputNode.value, 'oh my', 'string is set to property');
 });
 
 test("unquoted attribute expression works when followed by another attribute", function() {
   var template = compile('<div foo={{funstuff}} name="Alice"></div>');
-  var fragment = template.render({funstuff: "oh my"}, env);
+  var divNode = template.render({funstuff: "oh my"}, env).firstChild;
 
-  equalTokens(fragment, '<div foo="oh my" name="Alice"></div>');
+  equalTokens(divNode, '<div foo="oh my" name="Alice"></div>');
 });
 
 test("Unquoted attribute value with multiple nodes throws an exception", function () {
@@ -196,15 +193,15 @@ test("Unquoted attribute value with multiple nodes throws an exception", functio
 
 test("Simple elements can have arbitrary attributes", function() {
   var template = compile("<div data-some-data='foo'>content</div>");
-  var fragment = template.render({}, env);
-  equalTokens(fragment, '<div data-some-data="foo">content</div>');
+  var divNode = template.render({}, env).firstChild;
+  equalTokens(divNode, '<div data-some-data="foo">content</div>');
 });
 
 test("checked attribute and checked property are present after clone and hydrate", function() {
   var template = compile("<input checked=\"checked\">");
-  var fragment = template.render({}, env);
-  equal(fragment.tagName, 'INPUT', 'input tag');
-  equal(fragment.checked, true, 'input tag is checked');
+  var inputNode = template.render({}, env).firstChild;
+  equal(inputNode.tagName, 'INPUT', 'input tag');
+  equal(inputNode.checked, true, 'input tag is checked');
 });
 
 
@@ -350,9 +347,10 @@ test("The compiler can handle unescaped tr inside fragment table", function() {
   var template = compile('<table>{{#test}}{{{html}}}{{/test}}</table>');
   var context = { html: '<tr><td>Yo</td></tr>' };
   var fragment = template.render(context, env, document.createElement('div'));
+  var tableNode = fragment.firstChild;
 
   equal(
-    fragment.childNodes[1].tagName, 'TR',
+    tableNode.childNodes[1].tagName, 'TR',
     "root tr is present" );
 });
 
@@ -1058,65 +1056,65 @@ QUnit.module("HTML-based compiler (output, svg)", {
 
 test("Simple elements can have namespaced attributes", function() {
   var template = compile("<svg xlink:title='svg-title'>content</svg>");
-  var fragment = template.render({}, env);
+  var svgNode = template.render({}, env).firstChild;
 
-  equalTokens(fragment, '<svg xlink:title="svg-title">content</svg>');
-  equal(fragment.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
+  equalTokens(svgNode, '<svg xlink:title="svg-title">content</svg>');
+  equal(svgNode.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
 });
 
 test("Simple elements can have bound namespaced attributes", function() {
   var template = compile("<svg xlink:title={{title}}>content</svg>");
-  var fragment = template.render({title: 'svg-title'}, env);
+  var svgNode = template.render({title: 'svg-title'}, env).firstChild;
 
-  equalTokens(fragment, '<svg xlink:title="svg-title">content</svg>');
-  equal(fragment.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
+  equalTokens(svgNode, '<svg xlink:title="svg-title">content</svg>');
+  equal(svgNode.attributes[0].namespaceURI, 'http://www.w3.org/1999/xlink');
 });
 
 test("SVG element can have capitalized attributes", function() {
   var template = compile("<svg viewBox=\"0 0 0 0\"></svg>");
-  var fragment = template.render({}, env);
-  equalTokens(fragment, '<svg viewBox=\"0 0 0 0\"></svg>');
+  var svgNode = template.render({}, env).firstChild;
+  equalTokens(svgNode, '<svg viewBox=\"0 0 0 0\"></svg>');
 });
 
 test("The compiler can handle namespaced elements", function() {
   var html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
   var template = compile(html);
-  var fragment = template.render({}, env);
+  var svgNode = template.render({}, env).firstChild;
 
-  equal(fragment.namespaceURI, svgNamespace, "creates the svg element with a namespace");
-  equalTokens(fragment, html);
+  equal(svgNode.namespaceURI, svgNamespace, "creates the svg element with a namespace");
+  equalTokens(svgNode, html);
 });
 
 test("The compiler sets namespaces on nested namespaced elements", function() {
   var html = '<svg><path stroke="black" d="M 0 0 L 100 100"></path></svg>';
   var template = compile(html);
-  var fragment = template.render({}, env);
+  var svgNode = template.render({}, env).firstChild;
 
-  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+  equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
          "creates the path element with a namespace" );
-  equalTokens(fragment, html);
+  equalTokens(svgNode, html);
 });
 
 test("The compiler sets a namespace on an HTML integration point", function() {
   var html = '<svg><foreignObject>Hi</foreignObject></svg>';
   var template = compile(html);
-  var fragment = template.render({}, env);
+  var svgNode = template.render({}, env).firstChild;
 
-  equal( fragment.namespaceURI, svgNamespace,
+  equal( svgNode.namespaceURI, svgNamespace,
          "creates the svg element with a namespace" );
-  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+  equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
          "creates the foreignObject element with a namespace" );
-  equalTokens(fragment, html);
+  equalTokens(svgNode, html);
 });
 
 test("The compiler does not set a namespace on an element inside an HTML integration point", function() {
   var html = '<svg><foreignObject><div></div></foreignObject></svg>';
   var template = compile(html);
-  var fragment = template.render({}, env);
+  var svgNode = template.render({}, env).firstChild;
 
-  equal( fragment.childNodes[0].childNodes[0].namespaceURI, xhtmlNamespace,
+  equal( svgNode.childNodes[0].childNodes[0].namespaceURI, xhtmlNamespace,
          "creates the div inside the foreignObject without a namespace" );
-  equalTokens(fragment, html);
+  equalTokens(svgNode, html);
 });
 
 test("The compiler pops back to the correct namespace", function() {
@@ -1180,19 +1178,20 @@ test("svg can take some hydration", function() {
 
   var fragment = template.render({ name: 'Milly' }, env);
   equal(
-    fragment.childNodes[0].namespaceURI, svgNamespace,
+    fragment.firstChild.childNodes[0].namespaceURI, svgNamespace,
     "svg namespace inside a block is present" );
-  equalTokens( fragment, '<div><svg>Milly</svg></div>',
+  equalTokens( fragment.firstChild, '<div><svg>Milly</svg></div>',
              "html is valid" );
 });
 
 test("root svg can take some hydration", function() {
   var template = compile('<svg>{{name}}</svg>');
   var fragment = template.render({ name: 'Milly' }, env);
+  var svgNode = fragment.firstChild;
   equal(
-    fragment.namespaceURI, svgNamespace,
+    svgNode.namespaceURI, svgNamespace,
     "svg namespace inside a block is present" );
-  equalTokens( fragment, '<svg>Milly</svg>',
+  equalTokens( svgNode, '<svg>Milly</svg>',
              "html is valid" );
 });
 
@@ -1234,9 +1233,10 @@ test("Block helper allows namespace to bleed through", function() {
   var template = compile('<div><svg>{{#testing}}<circle />{{/testing}}</svg></div>');
 
   var fragment = template.render({ isTrue: true }, env);
-  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+  var svgNode = fragment.firstChild.firstChild;
+  equal( svgNode.namespaceURI, svgNamespace,
          "svg tag has an svg namespace" );
-  equal( fragment.childNodes[0].childNodes[0].namespaceURI, svgNamespace,
+  equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
          "circle tag inside block inside svg has an svg namespace" );
 });
 
@@ -1249,9 +1249,10 @@ test("Block helper with root svg allows namespace to bleed through", function() 
   var template = compile('<svg>{{#testing}}<circle />{{/testing}}</svg>');
 
   var fragment = template.render({ isTrue: true }, env);
-  equal( fragment.namespaceURI, svgNamespace,
+  var svgNode = fragment.firstChild;
+  equal( svgNode.namespaceURI, svgNamespace,
          "svg tag has an svg namespace" );
-  equal( fragment.childNodes[0].namespaceURI, svgNamespace,
+  equal( svgNode.childNodes[0].namespaceURI, svgNamespace,
          "circle tag inside block inside svg has an svg namespace" );
 });
 
@@ -1264,9 +1265,10 @@ test("Block helper with root foreignObject allows namespace to bleed through", f
   var template = compile('<foreignObject>{{#testing}}<div></div>{{/testing}}</foreignObject>');
 
   var fragment = template.render({ isTrue: true }, env, document.createElementNS(svgNamespace, 'svg'));
-  equal( fragment.namespaceURI, svgNamespace,
+  var svgNode = fragment.firstChild;
+  equal( svgNode.namespaceURI, svgNamespace,
          "foreignObject tag has an svg namespace" );
-  equal( fragment.childNodes[0].namespaceURI, xhtmlNamespace,
+  equal( svgNode.childNodes[0].namespaceURI, xhtmlNamespace,
          "div inside morph and foreignObject has xhtml namespace" );
 });
 

--- a/packages/htmlbars-compiler/tests/template-visitor-node-test.js
+++ b/packages/htmlbars-compiler/tests/template-visitor-node-test.js
@@ -30,10 +30,10 @@ test("basic", function() {
   var input = "foo{{bar}}<div></div>";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['text', [0, 3, false]],
+    ['text', [0, 3]],
     ['mustache', [1, 3]],
-    ['openElement', [2, 3, false, 0, []]],
-    ['closeElement', [2, 3, false]],
+    ['openElement', [2, 3, 0, []]],
+    ['closeElement', [2, 3]],
     ['endProgram', [0]]
   ]);
 });
@@ -42,14 +42,14 @@ test("nested HTML", function() {
   var input = "<a></a><a><a><a></a></a></a>";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['openElement', [0, 2, false, 0, []]],
-    ['closeElement', [0, 2, false]],
-    ['openElement', [1, 2, false, 0, []]],
-    ['openElement', [0, 1, false, 0, []]],
-    ['openElement', [0, 1, false, 0, []]],
-    ['closeElement', [0, 1, false]],
-    ['closeElement', [0, 1, false]],
-    ['closeElement', [1, 2, false]],
+    ['openElement', [0, 2, 0, []]],
+    ['closeElement', [0, 2]],
+    ['openElement', [1, 2, 0, []]],
+    ['openElement', [0, 1, 0, []]],
+    ['openElement', [0, 1, 0, []]],
+    ['closeElement', [0, 1]],
+    ['closeElement', [0, 1]],
+    ['closeElement', [1, 2]],
     ['endProgram', [0]]
   ]);
 });
@@ -58,19 +58,19 @@ test("mustaches are counted correctly", function() {
   var input = "<a><a>{{foo}}</a><a {{foo}}><a>{{foo}}</a><a>{{foo}}</a></a></a>";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['openElement', [0, 1, true, 2, []]],
-    ['openElement', [0, 2, false, 1, []]],
+    ['openElement', [0, 1, 2, []]],
+    ['openElement', [0, 2, 1, []]],
     ['mustache', [0, 1]],
-    ['closeElement', [0, 2, false]],
-    ['openElement', [1, 2, false, 3, []]],
-    ['openElement', [0, 2, false, 1, []]],
+    ['closeElement', [0, 2]],
+    ['openElement', [1, 2, 3, []]],
+    ['openElement', [0, 2, 1, []]],
     ['mustache', [0, 1]],
-    ['closeElement', [0, 2, false]],
-    ['openElement', [1, 2, false, 1, []]],
+    ['closeElement', [0, 2]],
+    ['openElement', [1, 2, 1, []]],
     ['mustache', [0, 1]],
-    ['closeElement', [1, 2, false]],
-    ['closeElement', [1, 2, false]],
-    ['closeElement', [0, 1, true]],
+    ['closeElement', [1, 2]],
+    ['closeElement', [1, 2]],
+    ['closeElement', [0, 1]],
     ['endProgram', [0]]
   ]);
 });
@@ -81,9 +81,9 @@ test("empty block", function() {
     ['startProgram', [0, []]],
     ['endProgram', [1]],
     ['startProgram', [1, [0, 1]]],
-    ['text', [0, 3, false]],
+    ['text', [0, 3]],
     ['block', [1, 3]],
-    ['text', [2, 3, false]],
+    ['text', [2, 3]],
     ['endProgram', [0]]
   ]);
 });
@@ -94,12 +94,12 @@ test("block with inverse", function() {
     ['startProgram', [0, []]],
     ['endProgram', [1]],
     ['startProgram', [0, []]],
-    ['text', [0, 1, true]],
+    ['text', [0, 1]],
     ['endProgram', [1]],
     ['startProgram', [2, [0, 1]]],
-    ['text', [0, 3, false]],
+    ['text', [0, 3]],
     ['block', [1, 3]],
-    ['text', [2, 3, false]],
+    ['text', [2, 3]],
     ['endProgram', [0]]
   ]);
 });
@@ -108,30 +108,30 @@ test("nested blocks", function() {
   var input = "{{#a}}{{#a}}<b></b>{{/a}}{{#a}}{{b}}{{/a}}{{/a}}{{#a}}b{{/a}}";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['text', [0, 1, true]],
+    ['text', [0, 1]],
     ['endProgram', [1]],
     ['startProgram', [0, [0, 1]]],
-    ['text', [0, 3, false]],
+    ['text', [0, 3]],
     ['mustache', [1, 3]],
-    ['text', [2, 3, false]],
+    ['text', [2, 3]],
     ['endProgram', [2]],
     ['startProgram', [0, []]],
-    ['openElement', [0, 1, true, 0, []]],
-    ['closeElement', [0, 1, true]],
+    ['openElement', [0, 1, 0, []]],
+    ['closeElement', [0, 1]],
     ['endProgram', [2]],
     ['startProgram', [2, [0, 1, 2]]],
-    ['text', [0, 5, false]],
+    ['text', [0, 5]],
     ['block', [1, 5]],
-    ['text', [2, 5, false]],
+    ['text', [2, 5]],
     ['block', [3, 5]],
-    ['text', [4, 5, false]],
+    ['text', [4, 5]],
     ['endProgram', [1]],
     ['startProgram', [2, [0, 1, 2]]],
-    ['text', [0, 5, false]],
+    ['text', [0, 5]],
     ['block', [1, 5]],
-    ['text', [2, 5, false]],
+    ['text', [2, 5]],
     ['block', [3, 5]],
-    ['text', [4, 5, false]],
+    ['text', [4, 5]],
     ['endProgram', [0]]
   ]);
 });
@@ -140,12 +140,12 @@ test("component", function() {
   var input = "<x-foo>bar</x-foo>";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['text', [0, 1, true]],
+    ['text', [0, 1]],
     ['endProgram', [1]],
     ['startProgram', [1, [0, 1]]],
-    ['text', [0, 3, false]],
+    ['text', [0, 3]],
     ['component', [1, 3]],
-    ['text', [2, 3, false]],
+    ['text', [2, 3]],
     ['endProgram', [0]]
   ]);
 });
@@ -154,7 +154,7 @@ test("comment", function() {
   var input = "<!-- some comment -->";
   actionsEqual(input, [
     ['startProgram', [0, []]],
-    ['comment', [0, 1, true]],
+    ['comment', [0, 1]],
     ['endProgram', [0]]
   ]);
 });

--- a/packages/morph-range/lib/main.js
+++ b/packages/morph-range/lib/main.js
@@ -150,17 +150,8 @@ Morph.prototype._updateText = function (parent, text) {
 };
 
 Morph.prototype._updateHTML = function (parent, html) {
-  var start = this.start, end = this.end;
-  clear(parent, start, end);
-  this.text = null;
-  var childNodes = this.domHelper.parseHTML(html, this.contextualElement);
-  appendChildren(parent, end, childNodes);
-  if (this.before !== null) {
-    this.before.end = start.nextSibling;
-  }
-  if (this.after !== null) {
-    this.after.start = end.previousSibling;
-  }
+  var fragment = this.domHelper.parseHTML(html, this.contextualElement);
+  this._updateNode(parent, fragment);
 };
 
 Morph.prototype.append = function (node) {
@@ -258,18 +249,6 @@ Morph.prototype.replace = function (index, removedLength, addedNodes) {
 
   splice.apply(morphs, args);
 };
-
-function appendChildren(parent, end, nodeList) {
-  var ref = end;
-  var i = nodeList.length;
-  var node;
-
-  while (i--) {
-    node = nodeList[i];
-    parent.insertBefore(node, ref);
-    ref = node;
-  }
-}
 
 function clear(parent, start, end) {
   var current, previous;


### PR DESCRIPTION
Depends on #279.

In practice this optimization seldom applies but complicates the code, tests and template mental model. (e.g. sometimes the template returns a fragment, sometimes it returns an element. This is noticed most in the brittleness of the tests.)

We can revisit it later with benchmarks but I suspect it is an unneeded micro-optimization which is not worth losing the simplicity of the always-fragment approach.