### PR TITLE
compilerSpec -> compileSpec

### DIFF
--- a/packages/htmlbars-compiler/lib/main.js
+++ b/packages/htmlbars-compiler/lib/main.js
@@ -1,9 +1,9 @@
 import {
   compile,
-  compilerSpec
+  compileSpec
 } from "./htmlbars-compiler/compiler";
 
 export {
   compile,
-  compilerSpec
+  compileSpec
 };


### PR DESCRIPTION
I've tried including `htmlbars-compiler` into my project and discovered that `compilerSpec` is not defined. Instead, `htmlbars-compiler/compiler` exports a function named `compileSpec`, which `htmlbars-compiler` mistakingly imports and re-exports as `compilerSpec`. It seems this file is not used anywhere else neither within HTMLBars nor in Ember. That's the only occurrence of the string `compilerSpec` in the entire project.