### PR TITLE
Ensure templates always have stable boundaries

### DIFF
--- a/packages/dom-helper/lib/main.js
+++ b/packages/dom-helper/lib/main.js
@@ -401,6 +401,12 @@ prototype.appendMorph = function(element, contextualElement) {
   return this.createMorph(element, insertion, insertion, contextualElement);
 };
 
+prototype.insertBoundary = function(fragment, index) {
+  // this will always be null or firstChild
+  var child = index === null ? null : this.childAtIndex(fragment, index);
+  this.insertBefore(fragment, this.createTextNode(''), child);
+};
+
 prototype.parseHTML = function(html, contextualElement) {
   var childNodes;
 

--- a/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
@@ -27,8 +27,18 @@ prototype.compile = function(opcodes, options) {
   this.parentCount = 0;
   this.indent = (options && options.indent) || "";
   this.hooks = {};
+  this.hasOpenBoundary = false;
+  this.hasCloseBoundary = false;
 
   processOpcodes(this, opcodes);
+
+  if (this.hasOpenBoundary) {
+    this.source.unshift(this.indent+"  dom.insertBoundary(fragment, 0);\n");
+  }
+
+  if (this.hasCloseBoundary) {
+    this.source.unshift(this.indent+"  dom.insertBoundary(fragment, null);\n");
+  }
 
   var i, l;
   if (this.morphs.length) {
@@ -73,6 +83,14 @@ prototype.prepareObject = function(size) {
 
 prototype.pushRaw = function(value) {
   this.stack.push(value);
+};
+
+prototype.openBoundary = function() {
+  this.hasOpenBoundary = true;
+};
+
+prototype.closeBoundary = function() {
+  this.hasCloseBoundary = true;
 };
 
 prototype.pushLiteral = function(value) {

--- a/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
@@ -119,8 +119,8 @@ HydrationOpcodeCompiler.prototype.closeElement = function() {
   this.currentDOMChildIndex = this.paths.pop();
 };
 
-HydrationOpcodeCompiler.prototype.mustache = function(mustache) {
-  this.pushMorphPlaceholderNode();
+HydrationOpcodeCompiler.prototype.mustache = function(mustache, childIndex, childCount) {
+  this.pushMorphPlaceholderNode(childIndex, childCount);
   
   var sexpr = mustache.sexpr;
 
@@ -138,8 +138,8 @@ HydrationOpcodeCompiler.prototype.mustache = function(mustache) {
   }
 };
 
-HydrationOpcodeCompiler.prototype.block = function(block) {
-  this.pushMorphPlaceholderNode();
+HydrationOpcodeCompiler.prototype.block = function(block, childIndex, childCount) {
+  this.pushMorphPlaceholderNode(childIndex, childCount);
 
   var sexpr = block.sexpr;
 
@@ -155,8 +155,8 @@ HydrationOpcodeCompiler.prototype.block = function(block) {
   this.opcode('printBlockHook', morphNum, templateId, inverseId);
 };
 
-HydrationOpcodeCompiler.prototype.component = function(component) {
-  this.pushMorphPlaceholderNode();
+HydrationOpcodeCompiler.prototype.component = function(component, childIndex, childCount) {
+  this.pushMorphPlaceholderNode(childIndex, childCount);
 
   var program = component.program || {};
   var blockParams = program.blockParams || [];
@@ -229,7 +229,15 @@ HydrationOpcodeCompiler.prototype.elementHelper = function(sexpr) {
   this.opcode('printElementHook', this.elementNum);
 };
 
-HydrationOpcodeCompiler.prototype.pushMorphPlaceholderNode = function() {
+HydrationOpcodeCompiler.prototype.pushMorphPlaceholderNode = function(childIndex, childCount) {
+  if (this.paths.length === 0) {
+    if (childIndex === 0) {
+      this.opcode('openBoundary');
+    }
+    if (childIndex === childCount - 1) {
+      this.opcode('closeBoundary');
+    }
+  }
   this.comment();
 };
 

--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -312,7 +312,7 @@ test("The compiler can handle top-level unescaped tr", function() {
   var fragment = template.render(context, env, document.createElement('table'));
 
   equal(
-    fragment.firstChild.tagName, 'TR',
+    fragment.firstChild.nextSibling.tagName, 'TR',
     "root tr is present" );
 });
 
@@ -322,7 +322,7 @@ test("The compiler can handle top-level unescaped td inside tr contextualElement
   var fragment = template.render(context, env, document.createElement('tr'));
 
   equal(
-    fragment.firstChild.tagName, 'TD',
+    fragment.firstChild.nextSibling.tagName, 'TD',
     "root td is returned" );
 });
 
@@ -336,7 +336,7 @@ test("The compiler can handle unescaped tr in top of content", function() {
   var fragment = template.render(context, env, document.createElement('table'));
 
   equal(
-    fragment.firstChild.tagName, 'TR',
+    fragment.firstChild.nextSibling.nextSibling.tagName, 'TR',
     "root tr is present" );
 });
 
@@ -351,7 +351,7 @@ test("The compiler can handle unescaped tr inside fragment table", function() {
   var tableNode = fragment.firstChild;
 
   equal(
-    tableNode.firstChild.tagName, 'TR',
+    tableNode.firstChild.nextSibling.tagName, 'TR',
     "root tr is present" );
 });
 
@@ -1221,16 +1221,16 @@ test("Block helper allows interior namespace", function() {
 
   var fragment = template.render({ isTrue: true }, env, document.body);
   equal(
-    fragment.firstChild.namespaceURI, svgNamespace,
+    fragment.firstChild.nextSibling.namespaceURI, svgNamespace,
     "svg namespace inside a block is present" );
 
   isTrue = false;
   fragment = template.render({ isTrue: false }, env, document.body);
   equal(
-    fragment.firstChild.namespaceURI, xhtmlNamespace,
+    fragment.firstChild.nextSibling.namespaceURI, xhtmlNamespace,
     "inverse block path has a normal namespace");
   equal(
-    fragment.firstChild.childNodes[0].namespaceURI, svgNamespace,
+    fragment.firstChild.nextSibling.firstChild.namespaceURI, svgNamespace,
     "svg namespace inside an element inside a block is present" );
 });
 

--- a/packages/htmlbars-compiler/tests/hydration-opcode-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/hydration-opcode-compiler-test.js
@@ -107,8 +107,10 @@ test("mustaches at the root", function() {
   deepEqual(opcodes, [
     [ "createMorph", [ 0, [ ], 0, 0, true ] ],
     [ "createMorph", [ 1, [ ], 2, 2, true ] ],
+    [ "openBoundary", [ ] ],
     [ "pushLiteral", [ "foo" ] ],
     [ "printContentHook", [ 0 ] ],
+    [ "closeBoundary", [ ] ],
     [ "pushLiteral", [ "bar" ] ],
     [ "printContentHook", [ 1 ] ]
   ]);


### PR DESCRIPTION
Previously, if a template’s first (or last) child was a dynamic node
(like a mustache or block), the associated render node’s firstChild or
lastChild would change.

```hbs
{{#if condition}}{{value}}{{/if}}
```

In this case, the render node associated with the `#if` helper cannot
have stable `firstNode` and `lastNode`, because when the nodes
associated with `value` change, the nodes associated with the `if`
helper must change as well.

The solution was to require that templates create fragments with stable
start and end nodes. If the first node is dynamic, we insert a boundary
empty text node to ensure that the template’s boundaries will not
change.

Conflicts:
	packages/htmlbars-compiler/lib/hydration-javascript-compiler.js
	packages/htmlbars-compiler/tests/dirtying-test.js
	packages/htmlbars-compiler/tests/html-compiler-test.js