### PR TITLE
Update ember-cli to 0.1.13.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "broccoli-string-replace": "~0.0.2",
     "broccoli-uglify-js": "~0.1.3",
     "chalk": "~0.4.0",
-    "ember-cli": "^0.1.6",
+    "ember-cli": "^0.1.13",
     "ember-cli-sauce": "0.0.7",
     "git-repo-version": "0.0.2",
     "handlebars": "mmun/handlebars.js#new-ast-3238645f",


### PR DESCRIPTION
Allows using `ember serve` to run tests.