### PR TITLE
Use ember-cli for tests instead of testem directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - SAUCE_USERNAME=htmlbars-ci
   - SAUCE_ACCESS_KEY=71947947-f373-4e9c-9166-23038df7ddf2
   matrix:
-  - TEST_NODE=1 TEST_BROWSERS=PhantomJS,SL_Chrome_Current,SL_Chrome_Last,SL_Firefox_Current,SL_Firefox_Last,SL_Safari_Current,SL_Safari_Last,SL_IE_11,SL_IE_10,SL_IE_9,SL_IE_8
+  - TEST_NODE=1 TEST_BROWSERS=1
 matrix:
   fast_finish: true
 before_script:

--- a/README.md
+++ b/README.md
@@ -34,15 +34,11 @@ info on how HTMLBars is structured and its approach to efficiently building / em
 
 # How to Run Tests
 
-## Via testem
+## Via Ember CLI
 
-[Testem](https://github.com/airportyh/testem) is a tool for running tests against
-multiple launchers. For instance, Chrome and PhantomJS.
+1. Run: `ember test --server`
 
-1. Install Testem: `npm install -g testem`
-2. Run testem: `testem` or run Testem with specific browers: `testem -l Safari,Firefox`
-
-Testem is a CI tool, so it will run tests as you change files.
+Ember CLI is a CI tool, so it will run tests as you change files.
 
 ## On the console with PhantomJS
 

--- a/bin/run-tests.js
+++ b/bin/run-tests.js
@@ -92,13 +92,13 @@ var testRuns = RSVP.resolve();
 
 if (process.env.CI && process.env.TEST_BROWSERS) {
   testRuns = testRuns.then(function() {
-    return runBrowserTests('./node_modules/.bin/testem', ['ci', '--port', '7000', '--timeout', '540', '-P', '2', '--launch', process.env.TEST_BROWSERS]);
+    return runBrowserTests('./node_modules/.bin/ember', ['test', '--port', '7000', '--config-file', './testem-sauce.json']);
   });
 }
 
 if (!process.env.CI) {
   testRuns = testRuns.then(function() {
-    return runBrowserTests('./node_modules/.bin/testem', ['ci', '--launch', 'PhantomJS']);
+    return runBrowserTests('./node_modules/.bin/ember', ['test']);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "handlebars": "mmun/handlebars.js#new-ast-3238645f",
     "morph-range": "^0.1.2",
     "qunit": "^0.7.2",
-    "rsvp": "~3.0.6",
-    "testem": "0.6.35"
+    "rsvp": "~3.0.6"
   }
 }

--- a/testem-sauce.json
+++ b/testem-sauce.json
@@ -1,0 +1,67 @@
+{
+  "framework": "qunit",
+  "test_page": "tests/index.html?hidepassed",
+  "timeout": 540,
+  "parallel": 2,
+  "launchers":
+    {
+      "SL_Chrome_Current": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b chrome -v 39 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_Chrome_Last": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b chrome -v 38 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_Firefox_Current": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b firefox -v 34 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_Firefox_Last": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b firefox -v 33 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_Safari_Current": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 8 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_Safari_Last": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 7 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_IE_11": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 11 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_IE_10": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 10 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_IE_9": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 9 --no-ct -u <url>",
+        "protocol": "tap"
+      },
+      "SL_IE_8": {
+        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 8 --no-ct -u <url>",
+        "protocol": "tap"
+      }
+    }
+  ,
+  "launch_in_dev": [
+    "PhantomJS",
+    "Chrome"
+  ],
+  "launch_in_ci": [
+    "PhantomJS",
+    "SL_Chrome_Current",
+    "SL_Chrome_Last",
+    "SL_Firefox_Current",
+    "SL_Firefox_Last",
+    "SL_Safari_Current",
+    "SL_Safari_Last",
+    "SL_IE_11",
+    "SL_IE_10",
+    "SL_IE_9",
+    "SL_IE_8"
+  ]
+}

--- a/testem.json
+++ b/testem.json
@@ -1,55 +1,6 @@
 {
   "framework": "qunit",
-  "test_page": "dist/tests/index.html?hidepassed",
-  "before_tests": "ember build",
-  "watch_files": [
-    "packages/**/*.js",
-    "tests/**/*.js"
-  ],
-  "launchers":
-    {
-      "SL_Chrome_Current": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b chrome -v 39 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_Chrome_Last": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b chrome -v 38 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_Firefox_Current": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b firefox -v 34 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_Firefox_Last": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b firefox -v 33 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_Safari_Current": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 8 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_Safari_Last": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b safari -v 7 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_IE_11": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 11 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_IE_10": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 10 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_IE_9": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 9 --no-ct -u <url>",
-        "protocol": "tap"
-      },
-      "SL_IE_8": {
-        "command": "./node_modules/.bin/ember-cli-sauce -b 'internet explorer' -v 8 --no-ct -u <url>",
-        "protocol": "tap"
-      }
-    }
-  ,
+  "test_page": "tests/index.html?hidepassed",
   "launch_in_dev": [
     "PhantomJS",
     "Chrome"


### PR DESCRIPTION
After https://github.com/tildeio/htmlbars/pull/293, this should works now.

* Use ember-cli for testing
* Moved cross-browser testing options into a separate config
* Removed testem dependency