### PR TITLE
Add revision to template output.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -174,7 +174,7 @@ for (var packageName in packages.dependencies) {
 }
 
 trees = replace(mergeTrees(trees, {overwrite: true}), {
-  files: [ 'es6/htmlbars.js', 'amd/htmlbars.js', 'cjs/htmlbars.js' ],
+  files: [ 'es6/htmlbars.js', 'es6/htmlbars-compiler/template-compiler.js', 'amd/htmlbars.js', 'cjs/htmlbars.js' ],
   patterns: [
     { match: /VERSION_STRING_PLACEHOLDER/g, replacement: getVersion() }
   ]

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chalk": "~0.4.0",
     "ember-cli": "^0.1.13",
     "ember-cli-sauce": "0.0.7",
-    "git-repo-version": "0.0.2",
+    "git-repo-version": "^0.1.2",
     "handlebars": "mmun/handlebars.js#new-ast-3238645f",
     "morph-range": "^0.1.2",
     "qunit": "^0.7.2",

--- a/packages/htmlbars-compiler/lib/template-compiler.js
+++ b/packages/htmlbars-compiler/lib/template-compiler.js
@@ -8,6 +8,7 @@ import { repeat } from "../htmlbars-util/quoting";
 
 function TemplateCompiler(options) {
   this.options = options || {};
+  this.revision = this.options.revision || "HTMLBars@VERSION_STRING_PLACEHOLDER";
   this.fragmentOpcodeCompiler = new FragmentOpcodeCompiler();
   this.fragmentCompiler = new FragmentJavaScriptCompiler();
   this.hydrationOpcodeCompiler = new HydrationOpcodeCompiler();
@@ -93,6 +94,7 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     this.getChildTemplateVars(indent + '  ') +
     indent+'  return {\n' +
     indent+'    isHTMLBars: true,\n' +
+    indent+'    revision: "' + this.revision + '",\n' +
     indent+'    blockParams: ' + blockParams.length + ',\n' +
     indent+'    cachedFragment: null,\n' +
     indent+'    hasRendered: false,\n' +

--- a/packages/htmlbars-compiler/tests/template-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/template-compiler-test.js
@@ -58,3 +58,12 @@ test("it omits unnecessary namespace changes", function () {
   equal(countNamespaceChanges('<div><svg><title><h1>foobar</h1></title></svg></div><svg></svg>'), 3);
 });
 
+test('it adds the provided revision to the template', function () {
+  var ast = preprocess('{{foo}}');
+  var compiler = new TemplateCompiler({
+    revision: 'FOO.BAR'
+  });
+  var program = compiler.compile(ast);
+
+  ok(program.indexOf('revision: "FOO.BAR"') > -1);
+});


### PR DESCRIPTION
It will use the current version (including SHA when not a tag) by default, but can be provided to the `compile` function.

The goal is to allow Ember to confirm that templates were compiled with the same compiler/revision as the running Ember version.

---

I'd like to pull this into 0.11 (Ember Canary) and 0.10 (Ember Beta) branches, to provide much better feedback when a mismatch has occurred.