### PR TITLE
Pass options through to AST plugins.

### DIFF
--- a/packages/htmlbars-syntax/lib/parser.js
+++ b/packages/htmlbars-syntax/lib/parser.js
@@ -31,7 +31,7 @@ export function preprocess(html, options) {
 
   if (options && options.plugins && options.plugins.ast) {
     for (var i = 0, l = options.plugins.ast.length; i < l; i++) {
-      var plugin = new options.plugins.ast[i]();
+      var plugin = new options.plugins.ast[i](options);
 
       plugin.syntax = syntax;
 


### PR DESCRIPTION
This allows AST plugins to have more information about the thing being compiled. The intent is for this to be a way to provide compile time template deprecations and still be able to indicate the module path for the template being compiled.

The general idea is that ember-cli-htmlbars will call `precompile` something like:

```javascript
var compiler = require('./bower_components/ember/ember-template-compiler');

var template = compiler.precompile(input, {
  moduleName: 'some-app/path/to-template/stuff'
});
```

And then Ember can have an AST preprocessor that deprecates things (like `{{bind-attr}}`) at compile time, but still provides the template path being compiled. Without the module name tracking down deprecations on compile is extremely difficult.