### PR TITLE
[DOC] Fix the URL for running tests in a browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Ember CLI is a CI tool, so it will run tests as you change files.
 ## In a browser
 
 1. Run `npm start`.
-2. Visit <http://localhost:4200/test>.
+2. Visit <http://localhost:4200/tests/>.


### PR DESCRIPTION
should be "/tests/" (with the trailing slash)