### PR TITLE
In HTML, <input> is a void element

### DIFF
--- a/demos/compile-and-run.html
+++ b/demos/compile-and-run.html
@@ -3,16 +3,25 @@
     <title>HTMLBars example</title>
   </head>
   <body>
-    <label>Data</label>
-    <textarea id="data">{"name": "Bob"}</textarea>
+    <label>
+      Data
+      <textarea id="data">{"name": "Bob"}</textarea>
+    </label>
 
-    <label>Template</label>
-    <textarea id="template">Howdy {{name}}</textarea>
+    <label>
+      Template
+      <textarea id="template">Howdy {{name}}</textarea>
+    </label>
 
-    <label>Options</label>
-    <textarea id="options">{ "disableComponentGeneration": true }</textarea>
+    <label>
+      Options
+      <textarea id="options">{ "disableComponentGeneration": true }</textarea>
+    </label>
 
-    <input id="skip-render" type="checkbox">Skip render?</input>
+    <label>
+      <input id="skip-render" type="checkbox">
+      Skip render?
+    </label>
 
     <button id="run-template">Compile and Render</button>
     <hr>


### PR DESCRIPTION
I was running `compile-and-run.html` through htmlbars (don't ask :stuck_out_tongue:), and it blew up because `</input>` is invalid HTML