### PR TITLE
Fix error for void elements

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -878,11 +878,14 @@ test("A helpful error message is provided for unmatched end tags", function() {
 });
 
 test("A helpful error message is provided for end tags for void elements", function() {
-  expect(2);
+  expect(3);
 
   QUnit.throws(function() {
     compile("<input></input>");
   }, /Invalid end tag `input` \(on line 1\) \(void elements cannot have end tags\)./);
+  QUnit.throws(function() {
+    compile("<div>\n  <input></input>\n</div>");
+  }, /Invalid end tag `input` \(on line 2\) \(void elements cannot have end tags\)./);
   QUnit.throws(function() {
     compile("\n\n</br>");
   }, /Invalid end tag `br` \(on line 3\) \(void elements cannot have end tags\)./);

--- a/packages/htmlbars-syntax/lib/token-handlers.js
+++ b/packages/htmlbars-syntax/lib/token-handlers.js
@@ -40,7 +40,7 @@ var tokenHandlers = {
 
     this.elementStack.push(element);
     if (voidMap.hasOwnProperty(tag.tagName) || tag.selfClosing) {
-      tokenHandlers.EndTag.call(this, tag);
+      tokenHandlers.EndTag.call(this, tag, true);
     }
   },
 
@@ -94,12 +94,12 @@ var tokenHandlers = {
     }
   },
 
-  EndTag: function(tag) {
+  EndTag: function(tag, selfClosing) {
     var element = this.elementStack.pop();
     var parent = this.currentElement();
     var disableComponentGeneration = this.options.disableComponentGeneration === true;
 
-    validateEndTag(tag, element);
+    validateEndTag(tag, element, selfClosing);
 
     if (disableComponentGeneration || element.tag.indexOf("-") === -1) {
       appendChild(parent, element);
@@ -114,12 +114,13 @@ var tokenHandlers = {
 
 };
 
-function validateEndTag(tag, element) {
+function validateEndTag(tag, element, selfClosing) {
   var error;
 
-  if (voidMap[tag.tagName] && element.tag === undefined) {
-    // For void elements, we check element.tag is undefined because endTag is called by the startTag token handler in
-    // the normal case, so checking only voidMap[tag.tagName] would lead to an error being thrown on the opening tag.
+  if (voidMap[tag.tagName] && !selfClosing) {
+    // EngTag is also called by StartTag for void and self-closing tags (i.e.
+    // <input> or <br />, so we need to check for that here. Otherwise, we would
+    // throw an error for those cases.
     error = "Invalid end tag " + formatEndTagInfo(tag) + " (void elements cannot have end tags).";
   } else if (element.tag === undefined) {
     error = "Closing tag " + formatEndTagInfo(tag) + " without an open tag.";


### PR DESCRIPTION
While looking at #323, I also noticed that the error message was "wrong" (inaccurate), so I fixed it and added a test case for it. Previously, the "void elements cannot have end tags" only work if this happens in the root context.

This is the minimal diff to pass the test. Open to suggestions to make it more elegant.

Input:

```html
<div>
  <input></input>
</div>
```

Before:

```
Closing tag `input` (on line 2) did not match last open tag `div` (on line 1).
```

After:

```
Invalid end tag `input` (on line 2) (void elements cannot have end tags).
```