### PR TITLE
Stable childEnv

### DIFF
--- a/packages/htmlbars-runtime/lib/expression-visitor.js
+++ b/packages/htmlbars-runtime/lib/expression-visitor.js
@@ -235,6 +235,9 @@ function dirtyCheck(env, morph, visitor, callback) {
   if (isDirty || isSubtreeDirty) {
     callback(visitor);
   } else {
+    if (morph.lastEnv) {
+      env = merge(morph.lastEnv, env);
+    }
     validateChildMorphs(env, morph, visitor);
   }
 }

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -537,7 +537,8 @@ function handleKeyword(path, morph, env, scope, params, hash, template, inverse,
   }
 
   if (keyword.childEnv) {
-    env = merge(keyword.childEnv(morph.state), env);
+    morph.lastEnv = keyword.childEnv(morph.state);
+    env = merge(morph.lastEnv, env);
   }
 
   var firstTime = !morph.rendered;

--- a/packages/htmlbars-runtime/lib/morph.js
+++ b/packages/htmlbars-runtime/lib/morph.js
@@ -11,6 +11,7 @@ function HTMLBarsMorph(domHelper, contextualElement) {
   this.lastYielded = null;
   this.lastResult = null;
   this.lastValue = null;
+  this.lastEnv = null;
   this.morphList = null;
   this.morphMap = null;
   this.key = null;


### PR DESCRIPTION
This let's a node's childEnv persist correctly when the node itself was
not dirty. It fixes and simplifies the way outlets inherit their state
in Glimmer.