### PR TITLE
Allow `element` hook to be customized.

### DIFF
--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -499,7 +499,7 @@ export function hostBlock(morph, env, scope, template, inverse, shadowOptions, v
   renderAndCleanup(morph, env, options, shadowOptions, callback);
 }
 
-function handleRedirect(morph, env, scope, path, params, hash, template, inverse, visitor) {
+export function handleRedirect(morph, env, scope, path, params, hash, template, inverse, visitor) {
   var redirect = env.hooks.classify(env, scope, path);
   if (redirect) {
     switch(redirect) {
@@ -518,7 +518,7 @@ function handleRedirect(morph, env, scope, path, params, hash, template, inverse
   return false;
 }
 
-function handleKeyword(path, morph, env, scope, params, hash, template, inverse, visitor) {
+export function handleKeyword(path, morph, env, scope, params, hash, template, inverse, visitor) {
   var keyword = env.hooks.keywords[path];
   if (!keyword) { return false; }
 


### PR DESCRIPTION
Export handleRedirect and handleKeyword from runtime.

This allows easier customization of hooks when handleRedirect and/or handleKeyword are needed.

The specific use-case/need is for a custom `element` hook in Ember, so that we can also add a deprecation when the helper returns a value to be added to an element (like `<div {{bind-attr id=foo}}></div>`).
