### PR TITLE
Add NullLiteral to HTMLBars.

### DIFF
--- a/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
+++ b/packages/htmlbars-compiler/lib/hydration-opcode-compiler.js
@@ -272,6 +272,10 @@ HydrationOpcodeCompiler.prototype.NumberLiteral = function(node) {
   this.opcode('pushLiteral', node.value);
 };
 
+HydrationOpcodeCompiler.prototype.NullLiteral = function(node) {
+  this.opcode('pushLiteral', node.value);
+};
+
 function preparePath(compiler, path) {
   compiler.opcode('pushLiteral', path.original);
 }

--- a/packages/htmlbars-runtime/lib/expression-visitor.js
+++ b/packages/htmlbars-runtime/lib/expression-visitor.js
@@ -36,7 +36,7 @@ var base = {
 
     // Primitive literals are unambiguously non-array representations of
     // themselves.
-    if (typeof node !== 'object') {
+    if (typeof node !== 'object' || node === null) {
       ret.value = node;
       return ret;
     }

--- a/packages/htmlbars-syntax/lib/builders.js
+++ b/packages/htmlbars-syntax/lib/builders.js
@@ -133,6 +133,14 @@ export function buildNumber(value) {
   };
 }
 
+export function buildNull() {
+  return {
+    type: "NullLiteral",
+    value: null,
+    original: null
+  };
+}
+
 // Miscellaneous
 
 export function buildHash(pairs) {
@@ -173,6 +181,7 @@ export default {
   string: buildString,
   boolean: buildBoolean,
   number: buildNumber,
+  null: buildNull,
   concat: buildConcat,
   hash: buildHash,
   pair: buildPair,

--- a/packages/htmlbars-syntax/lib/node-handlers.js
+++ b/packages/htmlbars-syntax/lib/node-handlers.js
@@ -108,7 +108,8 @@ var nodeHandlers = {
 
   StringLiteral: function() {},
   BooleanLiteral: function() {},
-  NumberLiteral: function() {}
+  NumberLiteral: function() {},
+  NullLiteral: function() {}
 };
 
 function switchToHandlebars(processor) {

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -476,3 +476,11 @@ test("an HTML comment", function() {
     b.text(" after")
   ]));
 });
+
+test("allow {{null}} to be passed", function() {
+  var ast = preprocess(parse("{{null}}"));
+
+  astEqual(ast, b.program([
+    b.mustache(b.null())
+  ]));
+});


### PR DESCRIPTION
The recent update to Handlebars 3.0.2 added `NullLiteral` to the list of known nodes.  This PR allows HTMLBars to handle this properly.

This fixes a few tests that the Handlebars update caused to fail in Ember.