### PR TITLE
Do not set `.value` property to the current value.

### DIFF
--- a/packages/morph-attr/lib/main.js
+++ b/packages/morph-attr/lib/main.js
@@ -5,6 +5,10 @@ import { getAttrNamespace } from "./htmlbars-util";
 
 function updateProperty(value) {
   if (this._renderedInitially === true || !isAttrRemovalValue(value)) {
+    if (this.attrName === 'value' && this.element.value === value) {
+      return;
+    }
+
     // do not render if initial value is undefined or null
     this.domHelper.setPropertyStrict(this.element, this.attrName, value);
   }


### PR DESCRIPTION
Allows preserving cursor position, during a re-render when a user is entering text into a bound input.