### PR TITLE
Add AttrMorph.prototype.clear and AttrMorph.prototype.destroy.

### DIFF
--- a/packages/morph-attr/lib/main.js
+++ b/packages/morph-attr/lib/main.js
@@ -89,6 +89,18 @@ AttrMorph.prototype.getContent = function () {
   return value;
 };
 
+// renderAndCleanup calls `clear` on all items in the morph map
+// just before calling `destroy` on the morph.
+//
+// As a future refactor this could be changed to set the property
+// back to its original/default value.
+AttrMorph.prototype.clear = function() { };
+
+AttrMorph.prototype.destroy = function() {
+  this.element = null;
+  this.domHelper = null;
+};
+
 export default AttrMorph;
 
 export { sanitizeAttributeValue };

--- a/packages/morph-attr/tests/attr-morph-test.js
+++ b/packages/morph-attr/tests/attr-morph-test.js
@@ -17,6 +17,23 @@ test("can update a dom node", function(){
   equal(element.getAttribute('id'), 'twang', 'id attribute is set');
 });
 
+test("can clear", function(){
+  expect(0);
+  var element = domHelper.createElement('div');
+  var morph = domHelper.createAttrMorph(element, 'id');
+  morph.clear();
+});
+
+test("calling destroy does not throw", function(){
+  expect(1);
+  var element = domHelper.createElement('div');
+  var morph = domHelper.createAttrMorph(element, 'id');
+
+  morph.destroy();
+
+  equal(morph.element, null, 'clears element from morph');
+});
+
 test("can update property", function(){
   var element = domHelper.createElement('input');
   var morph = domHelper.createAttrMorph(element, 'disabled');


### PR DESCRIPTION
These methods are called by `renderAndCleanup` (from `template-utils`)
when an AttrMorph is created in a block helpers template:

```javascript
    {{input type="checkbox" checked=checked}}

    {{#if checked}}
      <a href={{"http://google.com"}}>google.com</a>
    {{else}}
      <a href={{"http://yahoo.com"}}>yahoo.com</a>
    {{/if}}
```

In the above example, when `checked` is toggled the `href` AttrMorphs get `.clear()`
and `.destroy()` called on them.