### PR TITLE
Expose inverse block to component hook

### DIFF
--- a/packages/htmlbars-runtime/lib/expression-visitor.js
+++ b/packages/htmlbars-runtime/lib/expression-visitor.js
@@ -169,14 +169,18 @@ export var AlwaysDirtyVisitor = merge(createObject(base), {
     env.hooks.attribute(morph, env, scope, name, paramsAndHash[0][0]);
   },
 
-  // [ 'component', path, attrs, templateId ]
+  // [ 'component', path, attrs, templateId, inverseId ]
   component: function(node, morph, env, scope, template, visitor) {
-    var path = node[1], attrs = node[2], templateId = node[3];
+    var path = node[1], attrs = node[2], templateId = node[3], inverseId = node[4];
     var paramsAndHash = this.acceptParamsAndHash(env, scope, morph, path, [], attrs);
+    var templates = {
+      default: template.templates[templateId],
+      inverse: template.templates[inverseId]
+    };
 
     morph.isDirty = morph.isSubtreeDirty = false;
     env.hooks.component(morph, env, scope, path, paramsAndHash[0], paramsAndHash[1],
-                        template.templates[templateId], visitor);
+                        templates, visitor);
   }
 });
 

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -98,7 +98,7 @@ export function wrap(template) {
 }
 
 export function wrapForHelper(template, env, scope, morph, renderState, visitor) {
-  if (template === null) {
+  if (!template) {
     return {
       yieldIn: yieldInShadowTemplate(null, env, scope, morph, renderState, visitor)
     };
@@ -303,7 +303,7 @@ export function createFreshScope() {
   // because `in` checks have unpredictable performance, keep a
   // separate dictionary to track whether a local was bound.
   // See `bindLocal` for more information.
-  return { self: null, block: null, locals: {}, localPresent: {} };
+  return { self: null, blocks: {}, locals: {}, localPresent: {} };
 }
 
 /**
@@ -426,11 +426,13 @@ export function updateLocal(env, scope, name, value) {
   Corresponds to entering a shadow template that was invoked by a block helper with
   `yieldIn`.
 
-  This hook is invoked with an opaque block that will be passed along to the
-  shadow template, and inserted into the shadow template when `{{yield}}` is used.
+  This hook is invoked with an opaque block that will be passed along
+  to the shadow template, and inserted into the shadow template when
+  `{{yield}}` is used. Optionally provide a non-default block name
+  that can be targeted by `{{yield to=blockName}}`.
 */
-export function bindBlock(env, scope, block) {
-  scope.block = block;
+export function bindBlock(env, scope, block, name='default') {
+  scope.blocks[name] = block;
 }
 
 /**
@@ -505,7 +507,7 @@ export function handleRedirect(morph, env, scope, path, params, hash, template, 
   var redirect = env.hooks.classify(env, scope, path);
   if (redirect) {
     switch(redirect) {
-      case 'component': env.hooks.component(morph, env, scope, path, params, hash, template, visitor); break;
+      case 'component': env.hooks.component(morph, env, scope, path, params, hash, {default: template, inverse}, visitor); break;
       case 'inline': env.hooks.inline(morph, env, scope, path, params, hash, visitor); break;
       case 'block': env.hooks.block(morph, env, scope, path, params, hash, template, inverse, visitor); break;
       default: throw new Error("Internal HTMLBars redirection to " + redirect + " not supported");
@@ -703,11 +705,24 @@ export var keywords = {
   yield: function(morph, env, scope, params, hash, template, inverse, visitor) {
     // the current scope is provided purely for the creation of shadow
     // scopes; it should not be provided to user code.
-    if (scope.block) {
-      scope.block(env, params, hash.self, morph, scope, visitor);
+
+    var to = env.hooks.getValue(hash.to) || 'default';
+    if (scope.blocks[to]) {
+      scope.blocks[to](env, params, hash.self, morph, scope, visitor);
     }
     return true;
+  },
+
+  hasBlock: function(morph, env, scope, params) {
+    var name = env.hooks.getValue(params[0]) || 'default';
+    return !!scope.blocks[name];
+  },
+
+  hasBlockParams: function(morph, env, scope, params) {
+    var name = env.hooks.getValue(params[0]) || 'default';
+    return !!(scope.blocks[name] && scope.blocks[name].arity);
   }
+
 };
 
 /**
@@ -909,12 +924,12 @@ export function getCellOrValue(reference) {
   return reference;
 }
 
-export function component(morph, env, scope, tagName, params, attrs, template, visitor) {
+export function component(morph, env, scope, tagName, params, attrs, templates, visitor) {
   if (env.hooks.hasHelper(env, scope, tagName)) {
-    return env.hooks.block(morph, env, scope, tagName, params, attrs, template, null, visitor);
+    return env.hooks.block(morph, env, scope, tagName, params, attrs, templates.default, templates.inverse, visitor);
   }
 
-  componentFallback(morph, env, scope, tagName, attrs, template);
+  componentFallback(morph, env, scope, tagName, attrs, templates.default);
 }
 
 export function concat(env, params) {

--- a/packages/htmlbars-util/lib/template-utils.js
+++ b/packages/htmlbars-util/lib/template-utils.js
@@ -18,9 +18,7 @@ export function blockFor(render, template, blockOptions) {
         env.hooks.bindSelf(env, shadowScope, blockOptions.self);
       }
 
-      if (blockOptions.yieldTo !== undefined) {
-        env.hooks.bindBlock(env, shadowScope, blockOptions.yieldTo);
-      }
+      bindBlocks(env, shadowScope, blockOptions.yieldTo);
 
       renderAndCleanup(renderNode, env, options, null, function() {
         options.renderState.clearMorph = null;
@@ -32,6 +30,21 @@ export function blockFor(render, template, blockOptions) {
   block.arity = template.arity;
 
   return block;
+}
+
+function bindBlocks(env, shadowScope, blocks) {
+  if (!blocks) {
+    return;
+  }
+  if (typeof blocks === 'function') {
+    env.hooks.bindBlock(env, shadowScope, blocks);
+  } else {
+    for (var name in blocks) {
+      if (blocks.hasOwnProperty(name)) {
+        env.hooks.bindBlock(env, shadowScope, blocks[name], name);
+      }
+    }
+  }
 }
 
 export function renderAndCleanup(morph, env, options, shadowOptions, callback) {


### PR DESCRIPTION
This exposes the inverse template to the component hook, and parameterized `bindBlock` and `yield` so they can optionally use other block names (which will presumably just be "inverse" for now).