### PR TITLE
Add `meta` to template output.

### DIFF
--- a/packages/htmlbars-compiler/lib/template-compiler.js
+++ b/packages/htmlbars-compiler/lib/template-compiler.js
@@ -9,7 +9,7 @@ import { map } from "../htmlbars-util/array-utils";
 
 function TemplateCompiler(options) {
   this.options = options || {};
-  this.revision = this.options.revision || "HTMLBars@VERSION_STRING_PLACEHOLDER";
+  this.consumerBuildMeta = this.options.buildMeta || function() {};
   this.fragmentOpcodeCompiler = new FragmentOpcodeCompiler();
   this.fragmentCompiler = new FragmentJavaScriptCompiler();
   this.hydrationOpcodeCompiler = new HydrationOpcodeCompiler();
@@ -134,8 +134,7 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     '(function() {\n' +
     this.getChildTemplateVars(indent + '  ') +
     indent+'  return {\n' +
-    indent+'    isHTMLBars: true,\n' +
-    indent+'    revision: "' + this.revision + '",\n' +
+    this.buildMeta(indent+'    ', program) +
     indent+'    arity: ' + blockParams.length + ',\n' +
     indent+'    cachedFragment: null,\n' +
     indent+'    hasRendered: false,\n' +
@@ -149,6 +148,16 @@ TemplateCompiler.prototype.endProgram = function(program, programDepth) {
     indent+'}())';
 
   this.templates.push(template);
+};
+
+TemplateCompiler.prototype.buildMeta = function(indent, program) {
+  var meta = this.consumerBuildMeta(program) || {};
+
+  var head = indent+'meta: ';
+  var stringMeta = JSON.stringify(meta, null, 2).replace(/\n/g, '\n' + indent);
+  var tail = ',\n';
+
+  return head + stringMeta + tail;
 };
 
 TemplateCompiler.prototype.openElement = function(element, i, l, r, c, b) {

--- a/packages/htmlbars-compiler/tests/compile-tests.js
+++ b/packages/htmlbars-compiler/tests/compile-tests.js
@@ -1,0 +1,49 @@
+import { compile } from "../htmlbars-compiler/compiler";
+
+QUnit.module('compile: buildMeta');
+
+test('is merged into meta in template', function() {
+  var template = compile('Hi, {{name}}!', {
+    buildMeta: function() {
+      return { blah: 'zorz' };
+    }
+  });
+
+  equal(template.meta.blah, 'zorz', 'return value from buildMeta was pass through');
+});
+
+test('the program is passed to the callback function', function() {
+  var template = compile('Hi, {{name}}!', {
+    buildMeta: function(program) {
+      return { loc: program.loc };
+    }
+  });
+
+  equal(template.meta.loc.start.line, 1, 'the loc was passed through from program');
+});
+
+test('value keys are properly stringified', function() {
+  var template = compile('Hi, {{name}}!', {
+    buildMeta: function() {
+      return { 'loc-derp.lol': 'zorz' };
+    }
+  });
+
+  equal(template.meta['loc-derp.lol'], 'zorz', 'return value from buildMeta was pass through');
+});
+
+test('returning undefined does not throw errors', function () {
+  var template = compile('Hi, {{name}}!', {
+    buildMeta: function() {
+      return;
+    }
+  });
+
+  ok(template.meta, 'meta is present in template, even if empty');
+});
+
+test('options are not required for `compile`', function () {
+  var template = compile('Hi, {{name}}!');
+
+  ok(template.meta, 'meta is present in template, even if empty');
+});

--- a/packages/htmlbars-compiler/tests/template-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/template-compiler-test.js
@@ -18,13 +18,3 @@ test("it omits unnecessary namespace changes", function () {
   equal(countNamespaceChanges('<div><svg><title>foobar</title></svg></div><svg></svg>'), 1);
   equal(countNamespaceChanges('<div><svg><title><h1>foobar</h1></title></svg></div><svg></svg>'), 3);
 });
-
-test('it adds the provided revision to the template', function () {
-  var ast = preprocess('{{foo}}');
-  var compiler = new TemplateCompiler({
-    revision: 'FOO.BAR'
-  });
-  var program = compiler.compile(ast);
-
-  ok(program.indexOf('revision: "FOO.BAR"') > -1);
-});

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -81,9 +81,8 @@ export function wrap(template) {
   if (template === null) { return null;  }
 
   return {
-    isHTMLBars: true,
+    meta: template.meta,
     arity: template.arity,
-    revision: template.revision,
     raw: template,
     render: function(self, env, options, blockArguments) {
       var scope = env.hooks.createFreshScope();
@@ -107,8 +106,8 @@ export function wrapForHelper(template, env, scope, morph, renderState, visitor)
   var yieldArgs = yieldTemplate(template, env, scope, morph, renderState, visitor);
 
   return {
+    meta: template.meta,
     arity: template.arity,
-    revision: template.revision,
     yield: yieldArgs,
     yieldItem: yieldItem(template, env, scope, morph, renderState, visitor),
     yieldIn: yieldInShadowTemplate(template, env, scope, morph, renderState, visitor),

--- a/packages/htmlbars-runtime/lib/render.js
+++ b/packages/htmlbars-runtime/lib/render.js
@@ -85,8 +85,6 @@ export function manualElement(tagName, attributes) {
   statements.push(['content', 'yield']);
 
   var template = {
-    isHTMLBars: true,
-    revision: "HTMLBars@VERSION_STRING_PLACEHOLDER",
     arity: 0,
     cachedFragment: null,
     hasRendered: false,
@@ -247,4 +245,3 @@ export function getCachedFragment(template, env) {
 
   return fragment;
 }
-


### PR DESCRIPTION
Adds `buildMeta` callback to `compile` options.

If a `buildMeta` function is present in the options passed to `compile` or
`compileSpec`, the return value will be used for the `meta` key in the template
output.

This allows the host frameworks compiler to add metadata details (moduleName,
revision, etc) as needed.

```javascript
var template = compile('Hi, {{name}}!', {
  buildMeta: function(program) {
    return {
      isHTMLBars: true,
      revision: 'WAT@LOL.1234',
      loc: program.loc
    };
  }
});

template.meta.revision; // => 'WAT@LOL.1234'
```

---

Sample template output (no buildMeta callback):

```javascript
(function() {
  return {
    meta: {},
    arity: 0,
    cachedFragment: null,
    hasRendered: false,
    buildFragment: function buildFragment(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("Howdy ");
      dom.appendChild(el0, el1);
      var el1 = dom.createComment("");
      dom.appendChild(el0, el1);
      return el0;
    },
    buildRenderNodes: function buildRenderNodes(dom, fragment, contextualElement) {
      var morphs = new Array(1);
      morphs[0] = dom.createMorphAt(fragment,1,1,contextualElement);
      dom.insertBoundary(fragment, null);
      return morphs;
    },
    statements: [
      ["content","name"]
    ],
    locals: [],
    templates: []
  };
}())
```

Sample output with a general `buildMeta` as Ember might use it:

```javascript
(function() {
  return {
    meta: {
      "isHTMLBars": true,
      "revision": "SOME@REVISION",
      "moduleName": "my-app-name/templates/foo",
      "loc": {"source":null,"start":{"line":1,"column":0},"end":{"line":1,"column":14}}
    },
    arity: 0,
    cachedFragment: null,
    hasRendered: false,
    buildFragment: function buildFragment(dom) {
      var el0 = dom.createDocumentFragment();
      var el1 = dom.createTextNode("Howdy ");
      dom.appendChild(el0, el1);
      var el1 = dom.createComment("");
      dom.appendChild(el0, el1);
      return el0;
    },
    buildRenderNodes: function buildRenderNodes(dom, fragment, contextualElement) {
      var morphs = new Array(1);
      morphs[0] = dom.createMorphAt(fragment,1,1,contextualElement);
      dom.insertBoundary(fragment, null);
      return morphs;
    },
    statements: [
      ["content","name"]
    ],
    locals: [],
    templates: []
  };
}())
```