### PR TITLE
Do not attempt to redirect null paths

### DIFF
--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -503,6 +503,10 @@ export function hostBlock(morph, env, scope, template, inverse, shadowOptions, v
 }
 
 export function handleRedirect(morph, env, scope, path, params, hash, template, inverse, visitor) {
+  if (!path) {
+    return false;
+  }
+
   var redirect = env.hooks.classify(env, scope, path);
   if (redirect) {
     switch(redirect) {


### PR DESCRIPTION
`null` paths were being passed to the `classify` and `handleKeyword` hook. This was obviously not intended, and the fact that code in `classify` and `handleKeyword` is safe for a `null` path was not intentional.

This fixes https://github.com/emberjs/ember.js/pull/11223 in Ember.