### PR TITLE
attempt at fixing SVG integration elements

### DIFF
--- a/packages/htmlbars-compiler/lib/fragment-javascript-compiler.js
+++ b/packages/htmlbars-compiler/lib/fragment-javascript-compiler.js
@@ -41,6 +41,9 @@ FragmentJavaScriptCompiler.prototype.createElement = function(tagName) {
   this.source.push(this.indent+'  var '+el+' = dom.createElement('+string(tagName)+');\n');
   if (svgHTMLIntegrationPoints[tagName]) {
     this.pushNamespaceFrame({namespace: null, depth: this.depth});
+    // reset the namespace in cases like when using manualElement
+    // this will cause dom.setNamespace to be called twice
+    this.source.push(this.indent+'  dom.setNamespace(null);\n');
   }
 };
 

--- a/packages/htmlbars-runtime/tests/main-test.js
+++ b/packages/htmlbars-runtime/tests/main-test.js
@@ -1,4 +1,4 @@
-/*globals SVGElement, SVGLinearGradientElement */
+/*globals SVGElement, SVGLinearGradientElement, SVGForeignObjectElement, HTMLDivElement */
 import { hooks } from "../htmlbars-runtime";
 import { manualElement } from "../htmlbars-runtime/render";
 import { compile } from "../htmlbars-compiler/compiler";
@@ -111,4 +111,38 @@ test("manualElement function honors void elements", function() {
   equal(fragment.childNodes.length, 1, 'includes a single element');
   equal(fragment.childNodes[0].childNodes.length, 0, 'no child nodes were added to `<input>` because it is a void tag');
   equalTokens(fragment, '<input class="foo-bar">');
+});
+
+test("manualElement function honors svg integration", function() {
+  var env = {
+    dom: new DOMHelper(),
+    hooks: hooks,
+    helpers: {},
+    partials: {},
+    useFragmentCache: true
+  };
+  hooks.keywords['manual-element'] = {
+      render: function(morph, env, scope, params, hash, template, inverse, visitor) {
+        var attributes = {
+          version: '1.1'
+        };
+
+        var layout = manualElement('svg', attributes);
+
+        hostBlock(morph, env, scope, template, inverse, null, visitor, function(options) {
+          options.templates.template.yieldIn({ raw: layout }, hash);
+        });
+
+        manualElement(env, scope, 'span', attributes, morph);
+      },
+
+      isStable: function() { return true; }
+    };
+
+    var template = compile('{{#manual-element}}<foreignObject><div><b></b></div></foreignObject>{{/manual-element}}');
+    var result = template.render({startOffset:0.1, stopOffset:0.6}, env);
+    ok(result.fragment.childNodes[1] instanceof SVGElement);
+    ok(result.fragment.childNodes[1].childNodes[0] instanceof SVGForeignObjectElement);
+    ok(result.fragment.childNodes[1].childNodes[0].childNodes[0] instanceof HTMLDivElement);
+    equalTokens(result.fragment, '<svg version="1.1"><foreignObject><div><b></b></div></foreignObject></svg>');
 });


### PR DESCRIPTION
This adds an extra `dom.setNamespace` which fixes the integration object issues but fails a test that checks for unnecessary `dom.setNamepsace` calls. not the best approach but it works.