### PR TITLE
Helper streams require get

### DIFF
--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -661,7 +661,7 @@ export function inline(morph, env, scope, path, params, hash, visitor) {
     var result = env.hooks.invokeHelper(morph, env, scope, visitor, params, hash, helper, options.templates, thisFor(options.templates));
 
     if (result && 'value' in result) {
-      value = result.value;
+      value = env.hooks.getValue(result.value);
       hasValue = true;
     }
 
@@ -877,7 +877,7 @@ export function attribute(morph, env, scope, name, value) {
 export function subexpr(env, scope, helperName, params, hash) {
   var helper = env.hooks.lookupHelper(env, scope, helperName);
   var result = env.hooks.invokeHelper(null, env, scope, null, params, hash, helper, {});
-  if (result && 'value' in result) { return result.value; }
+  if (result && 'value' in result) { return env.hooks.getValue(result.value); }
 }
 
 /**


### PR DESCRIPTION
If `invokeHelper` is to return a stream, we must ensure that stream always has a value generated. Sometimes a stream's compute function may yield a block instead of generate a value.

This forces compute to happen once.

There is probably a better way to achieve the base goal here. For example, I should likely only link nodes that a new-style `Ember.Helper`, where they cannot interact with `yield` etc.

See also: https://github.com/mixonic/ember.js/pull/8