### PR TITLE
link to content results (ember helpers)

### DIFF
--- a/packages/htmlbars-runtime/lib/expression-visitor.js
+++ b/packages/htmlbars-runtime/lib/expression-visitor.js
@@ -137,6 +137,9 @@ export var AlwaysDirtyVisitor = merge(createObject(base), {
 
     if (isHelper(env, scope, path)) {
       env.hooks.inline(morph, env, scope, path, [], {}, visitor);
+      if (morph.linkedResult) {
+        linkParams(env, scope, morph, '@content-helper', [morph.linkedResult], null);
+      }
       return;
     }
 


### PR DESCRIPTION
`morph.linkedResults` must be linked for helpers to rerender upon invalidation.