### PR TITLE
Implement new visitor

### DIFF
--- a/packages/htmlbars-syntax/lib/main.js
+++ b/packages/htmlbars-syntax/lib/main.js
@@ -1,9 +1,11 @@
 import Walker from "./htmlbars-syntax/walker";
 import builders from "./htmlbars-syntax/builders";
 import parse from "./htmlbars-syntax/parser";
+import traverse from "./htmlbars-syntax/traversal/traverse";
 
 export {
   Walker,
   builders,
-  parse
+  parse,
+  traverse
 };

--- a/packages/htmlbars-syntax/lib/traversal/traverse.js
+++ b/packages/htmlbars-syntax/lib/traversal/traverse.js
@@ -1,0 +1,62 @@
+import visitorKeys from '../types/visitor-keys';
+
+function visitNode(node, visitor) {
+  let handler = visitor[node.type];
+
+  if (handler && handler.enter) {
+    handler.enter.call(null, node);
+  }
+
+  visitChildNodes(node, visitor);
+
+  if (handler && handler.exit) {
+    handler.exit.call(null, node);
+  }
+}
+
+function visitChildNodes(node, visitor) {
+  let keys = visitorKeys[node.type];
+
+  for (let i = 0; i < keys.length; i++) {
+    let child = node[keys[i]];
+    if (child) {
+      if (Array.isArray(child)) {
+        visitArrayOfNodes(child, visitor);
+      } else {
+        visitNode(child, visitor);
+      }
+    }
+  }
+}
+
+function visitArrayOfNodes(nodes, visitor) {
+  for (let i = 0; i < nodes.length; i++) {
+    visitNode(nodes[i], visitor);
+  }
+}
+
+export default function traverse(node, visitor) {
+  visitNode(node, normalizeVisitor(visitor));
+}
+
+function normalizeVisitor(visitor) {
+  let normalizedVisitor = {};
+
+  for (let type in visitor) {
+    let handler = visitor[type];
+
+    if (typeof handler === 'object') {
+      normalizedVisitor[type] = {
+        enter: (typeof handler.enter === 'function') ? handler.enter : null,
+        exit: (typeof handler.exit === 'function') ? handler.exit : null
+      };
+    } else if (typeof handler === 'function') {
+      normalizedVisitor[type] = {
+        enter: handler,
+        exit: null
+      };
+    }
+  }
+
+  return normalizedVisitor;
+}

--- a/packages/htmlbars-syntax/lib/types/visitor-keys.js
+++ b/packages/htmlbars-syntax/lib/types/visitor-keys.js
@@ -1,0 +1,26 @@
+export default {
+  Program:                  ['body'],
+
+  MustacheStatement:        ['path', 'params', 'hash'],
+  BlockStatement:           ['path', 'params', 'hash', 'program', 'inverse'],
+  ElementModifierStatement: ['path', 'params', 'hash'],
+  PartialStatement:         ['name', 'params', 'hash'],
+  CommentStatement:         [],
+  ElementNode:              ['attributes', 'modifiers', 'children'],
+  ComponentNode:            ['attributes', 'program'],
+  AttrNode:                 ['value'],
+  TextNode:                 [],
+
+  ConcatStatement:          ['parts'],
+  SubExpression:            ['path', 'params', 'hash'],
+  PathExpression:           [],
+
+  StringLiteral:            [],
+  BooleanLiteral:           [],
+  NumberLiteral:            [],
+  NullLiteral:              [],
+  UndefinedLiteral:         [],
+
+  Hash:                     ['pairs'],
+  HashPair:                 ['value']
+};

--- a/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
@@ -1,0 +1,315 @@
+import { parse, traverse } from '../../htmlbars-syntax';
+import visitorKeys from '../../htmlbars-syntax/types/visitor-keys';
+
+let actualTraversal;
+let assertionVisitor = {};
+
+for (let key in visitorKeys) {
+  assertionVisitor[key] = {
+    enter(node) { actualTraversal.push(['enter', node]); },
+    exit(node) { actualTraversal.push(['exit',  node]); }
+  };
+}
+
+function traversalEqual(node, expectedTraversal) {
+  actualTraversal = [];
+  traverse(node, assertionVisitor);
+
+  deepEqual(
+    actualTraversal.map(a => `${a[0]}:${a[1].type}`),
+    expectedTraversal.map(a => `${a[0]}:${a[1].type}`)
+  );
+
+  let nodesEqual = true;
+
+  for (let i = 0; i < actualTraversal.length; i++) {
+    if (actualTraversal[i][1] !== expectedTraversal[i][1]) {
+      nodesEqual = false;
+      break;
+    }
+  }
+
+  ok(nodesEqual, "Actual nodes match expected nodes");
+
+  actualTraversal = null;
+}
+
+QUnit.module('Traversal - visiting');
+
+test('Elements and attributes', function() {
+  let ast = parse(`<div id="id" class="large {{classes}}" value={{value}}><b></b><b></b></div>`);
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].attributes[0]],
+    ['enter', ast.body[0].attributes[0].value],
+    ['exit',  ast.body[0].attributes[0].value],
+    ['exit',  ast.body[0].attributes[0]],
+    ['enter', ast.body[0].attributes[1]],
+    ['enter', ast.body[0].attributes[1].value],
+    ['enter', ast.body[0].attributes[1].value.parts[0]],
+    ['exit',  ast.body[0].attributes[1].value.parts[0]],
+    ['enter', ast.body[0].attributes[1].value.parts[1]],
+    ['exit',  ast.body[0].attributes[1].value.parts[1]],
+    ['exit',  ast.body[0].attributes[1].value],
+    ['exit',  ast.body[0].attributes[1]],
+    ['enter', ast.body[0].attributes[2]],
+    ['enter', ast.body[0].attributes[2].value],
+    ['enter', ast.body[0].attributes[2].value.path],
+    ['exit',  ast.body[0].attributes[2].value.path],
+    ['enter', ast.body[0].attributes[2].value.hash],
+    ['exit',  ast.body[0].attributes[2].value.hash],
+    ['exit',  ast.body[0].attributes[2].value],
+    ['exit',  ast.body[0].attributes[2]],
+    ['enter', ast.body[0].children[0]],
+    ['exit',  ast.body[0].children[0]],
+    ['enter', ast.body[0].children[1]],
+    ['exit',  ast.body[0].children[1]],
+    ['exit',  ast.body[0]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Element modifiers', function() {
+  let ast = parse(`<div {{modifier}}{{modifier param1 param2 key1=value key2=value}}></div>`);
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].modifiers[0]],
+    ['enter', ast.body[0].modifiers[0].path],
+    ['exit',  ast.body[0].modifiers[0].path],
+    ['enter', ast.body[0].modifiers[0].hash],
+    ['exit',  ast.body[0].modifiers[0].hash],
+    ['exit',  ast.body[0].modifiers[0]],
+    ['enter', ast.body[0].modifiers[1]],
+    ['enter', ast.body[0].modifiers[1].path],
+    ['exit',  ast.body[0].modifiers[1].path],
+    ['enter', ast.body[0].modifiers[1].params[0]],
+    ['exit',  ast.body[0].modifiers[1].params[0]],
+    ['enter', ast.body[0].modifiers[1].params[1]],
+    ['exit',  ast.body[0].modifiers[1].params[1]],
+    ['enter', ast.body[0].modifiers[1].hash],
+    ['enter', ast.body[0].modifiers[1].hash.pairs[0]],
+    ['enter', ast.body[0].modifiers[1].hash.pairs[0].value],
+    ['exit',  ast.body[0].modifiers[1].hash.pairs[0].value],
+    ['exit' , ast.body[0].modifiers[1].hash.pairs[0]],
+    ['enter', ast.body[0].modifiers[1].hash.pairs[1]],
+    ['enter', ast.body[0].modifiers[1].hash.pairs[1].value],
+    ['exit',  ast.body[0].modifiers[1].hash.pairs[1].value],
+    ['exit' , ast.body[0].modifiers[1].hash.pairs[1]],
+    ['exit',  ast.body[0].modifiers[1].hash],
+    ['exit',  ast.body[0].modifiers[1]],
+    ['exit',  ast.body[0]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Blocks', function() {
+  let ast = parse(
+    `{{#block}}{{/block}}` +
+    `{{#block param1 param2 key1=value key2=value}}<b></b><b></b>{{/block}}`
+  );
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].path],
+    ['exit',  ast.body[0].path],
+    ['enter', ast.body[0].hash],
+    ['exit',  ast.body[0].hash],
+    ['enter', ast.body[0].program],
+    ['exit',  ast.body[0].program],
+    ['exit',  ast.body[0]],
+    ['enter', ast.body[1]],
+    ['enter', ast.body[1].path],
+    ['exit',  ast.body[1].path],
+    ['enter', ast.body[1].params[0]],
+    ['exit',  ast.body[1].params[0]],
+    ['enter', ast.body[1].params[1]],
+    ['exit',  ast.body[1].params[1]],
+    ['enter', ast.body[1].hash],
+    ['enter', ast.body[1].hash.pairs[0]],
+    ['enter', ast.body[1].hash.pairs[0].value],
+    ['exit',  ast.body[1].hash.pairs[0].value],
+    ['exit',  ast.body[1].hash.pairs[0]],
+    ['enter', ast.body[1].hash.pairs[1]],
+    ['enter', ast.body[1].hash.pairs[1].value],
+    ['exit',  ast.body[1].hash.pairs[1].value],
+    ['exit',  ast.body[1].hash.pairs[1]],
+    ['exit',  ast.body[1].hash],
+    ['enter', ast.body[1].program],
+    ['enter', ast.body[1].program.body[0]],
+    ['exit',  ast.body[1].program.body[0]],
+    ['enter', ast.body[1].program.body[1]],
+    ['exit',  ast.body[1].program.body[1]],
+    ['exit',  ast.body[1].program],
+    ['exit',  ast.body[1]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Mustaches', function() {
+  let ast = parse(
+    `{{mustache}}` +
+    `{{mustache param1 param2 key1=value key2=value}}`
+  );
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].path],
+    ['exit',  ast.body[0].path],
+    ['enter', ast.body[0].hash],
+    ['exit',  ast.body[0].hash],
+    ['exit',  ast.body[0]],
+    ['enter', ast.body[1]],
+    ['enter', ast.body[1].path],
+    ['exit',  ast.body[1].path],
+    ['enter', ast.body[1].params[0]],
+    ['exit',  ast.body[1].params[0]],
+    ['enter', ast.body[1].params[1]],
+    ['exit',  ast.body[1].params[1]],
+    ['enter', ast.body[1].hash],
+    ['enter', ast.body[1].hash.pairs[0]],
+    ['enter', ast.body[1].hash.pairs[0].value],
+    ['exit',  ast.body[1].hash.pairs[0].value],
+    ['exit',  ast.body[1].hash.pairs[0]],
+    ['enter', ast.body[1].hash.pairs[1]],
+    ['enter', ast.body[1].hash.pairs[1].value],
+    ['exit',  ast.body[1].hash.pairs[1].value],
+    ['exit',  ast.body[1].hash.pairs[1]],
+    ['exit',  ast.body[1].hash],
+    ['exit',  ast.body[1]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Components', function() {
+  let ast = parse(
+    `<x-block />` +
+    `<x-block></x-block>` +
+    `<x-block id="id" class="large {{classes}}" value={{value}}><b></b><b></b></x-block>`
+  );
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].program],
+    ['exit',  ast.body[0].program],
+    ['exit',  ast.body[0]],
+    ['enter', ast.body[1]],
+    ['enter', ast.body[1].program],
+    ['exit',  ast.body[1].program],
+    ['exit',  ast.body[1]],
+    ['enter', ast.body[2]],
+    ['enter', ast.body[2].attributes[0]],
+    ['enter', ast.body[2].attributes[0].value],
+    ['exit',  ast.body[2].attributes[0].value],
+    ['exit',  ast.body[2].attributes[0]],
+    ['enter', ast.body[2].attributes[1]],
+    ['enter', ast.body[2].attributes[1].value],
+    ['enter', ast.body[2].attributes[1].value.parts[0]],
+    ['exit',  ast.body[2].attributes[1].value.parts[0]],
+    ['enter', ast.body[2].attributes[1].value.parts[1]],
+    ['exit',  ast.body[2].attributes[1].value.parts[1]],
+    ['exit',  ast.body[2].attributes[1].value],
+    ['exit',  ast.body[2].attributes[1]],
+    ['enter', ast.body[2].attributes[2]],
+    ['enter', ast.body[2].attributes[2].value],
+    ['enter', ast.body[2].attributes[2].value.path],
+    ['exit',  ast.body[2].attributes[2].value.path],
+    ['enter', ast.body[2].attributes[2].value.hash],
+    ['exit',  ast.body[2].attributes[2].value.hash],
+    ['exit',  ast.body[2].attributes[2].value],
+    ['exit',  ast.body[2].attributes[2]],
+    ['enter', ast.body[2].program],
+    ['enter', ast.body[2].program.body[0]],
+    ['exit',  ast.body[2].program.body[0]],
+    ['enter', ast.body[2].program.body[1]],
+    ['exit',  ast.body[2].program.body[1]],
+    ['exit',  ast.body[2].program],
+    ['exit',  ast.body[2]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Nested helpers', function() {
+  let ast = parse(`{{helper
+    (helper param1 param2 key1=value key2=value)
+    key1=(helper param)
+    key2=(helper key=(helper param))
+  }}`);
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['enter', ast.body[0].path],
+    ['exit',  ast.body[0].path],
+    ['enter', ast.body[0].params[0]],
+    ['enter', ast.body[0].params[0].path],
+    ['exit',  ast.body[0].params[0].path],
+    ['enter', ast.body[0].params[0].params[0]],
+    ['exit',  ast.body[0].params[0].params[0]],
+    ['enter', ast.body[0].params[0].params[1]],
+    ['exit',  ast.body[0].params[0].params[1]],
+    ['enter', ast.body[0].params[0].hash],
+    ['enter', ast.body[0].params[0].hash.pairs[0]],
+    ['enter', ast.body[0].params[0].hash.pairs[0].value],
+    ['exit',  ast.body[0].params[0].hash.pairs[0].value],
+    ['exit',  ast.body[0].params[0].hash.pairs[0]],
+    ['enter', ast.body[0].params[0].hash.pairs[1]],
+    ['enter', ast.body[0].params[0].hash.pairs[1].value],
+    ['exit',  ast.body[0].params[0].hash.pairs[1].value],
+    ['exit',  ast.body[0].params[0].hash.pairs[1]],
+    ['exit',  ast.body[0].params[0].hash],
+    ['exit',  ast.body[0].params[0]],
+    ['enter', ast.body[0].hash],
+    ['enter', ast.body[0].hash.pairs[0]],
+    ['enter', ast.body[0].hash.pairs[0].value],
+    ['enter', ast.body[0].hash.pairs[0].value.path],
+    ['exit',  ast.body[0].hash.pairs[0].value.path],
+    ['enter', ast.body[0].hash.pairs[0].value.params[0]],
+    ['exit',  ast.body[0].hash.pairs[0].value.params[0]],
+    ['enter', ast.body[0].hash.pairs[0].value.hash],
+    ['exit',  ast.body[0].hash.pairs[0].value.hash],
+    ['exit',  ast.body[0].hash.pairs[0].value],
+    ['exit',  ast.body[0].hash.pairs[0]],
+    ['enter', ast.body[0].hash.pairs[1]],
+    ['enter', ast.body[0].hash.pairs[1].value],
+    ['enter', ast.body[0].hash.pairs[1].value.path],
+    ['exit',  ast.body[0].hash.pairs[1].value.path],
+    ['enter', ast.body[0].hash.pairs[1].value.hash],
+    ['enter', ast.body[0].hash.pairs[1].value.hash.pairs[0]],
+    ['enter', ast.body[0].hash.pairs[1].value.hash.pairs[0].value],
+    ['enter', ast.body[0].hash.pairs[1].value.hash.pairs[0].value.path],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash.pairs[0].value.path],
+    ['enter', ast.body[0].hash.pairs[1].value.hash.pairs[0].value.params[0]],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash.pairs[0].value.params[0]],
+    ['enter', ast.body[0].hash.pairs[1].value.hash.pairs[0].value.hash],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash.pairs[0].value.hash],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash.pairs[0].value],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash.pairs[0]],
+    ['exit',  ast.body[0].hash.pairs[1].value.hash],
+    ['exit',  ast.body[0].hash.pairs[1].value],
+    ['exit',  ast.body[0].hash.pairs[1]],
+    ['exit',  ast.body[0].hash],
+    ['exit',  ast.body[0]],
+    ['exit',  ast]
+  ]);
+});
+
+test('Comments', function() {
+  let ast = parse(`<!-- HTML comment -->{{!-- Handlebars comment --}}`);
+
+  traversalEqual(ast, [
+    ['enter', ast],
+    ['enter', ast.body[0]],
+    ['exit',  ast.body[0]],
+    // TODO: Ensure Handlebars comments are in the AST.
+    // ['enter', ast.body[1]],
+    // ['exit',  ast.body[1]],
+    ['exit',  ast]
+  ]);
+});


### PR DESCRIPTION
Implements a new visitor that fully traverses the AST. It was designed in the spirit of Babel's transform. Usage:

```js
import { traverse } from "htmlbars-syntax";

let ast = parse(`{{name-tag name=(upcase user.name)}}`);

traverse(ast, {
  PathExpression(node) {
    console.log(node.original); // Logs "name-tag", "upcase", "user.name"
  }
});
```

Alternatively, you can use the enter/exit format to capture when the node is entered and exited:

```js
import { traverse } from "htmlbars-syntax";

let ast = parse(`...`);
let depth = -1;

traverse(ast, {
  Program: {
    enter() { depth++; },
    exit() { depth--; }
  }
});
```