### PR TITLE
Implement replacement API

### DIFF
--- a/packages/htmlbars-syntax/lib/builders.js
+++ b/packages/htmlbars-syntax/lib/builders.js
@@ -3,7 +3,7 @@
 export function buildMustache(path, params, hash, raw, loc) {
   return {
     type: "MustacheStatement",
-    path: path,
+    path: buildPath(path),
     params: params || [],
     hash: hash || buildHash([]),
     escaped: !raw,
@@ -14,7 +14,7 @@ export function buildMustache(path, params, hash, raw, loc) {
 export function buildBlock(path, params, hash, program, inverse, loc) {
   return {
     type: "BlockStatement",
-    path: path,
+    path: buildPath(path),
     params: params || [],
     hash: hash || buildHash([]),
     program: program || null,
@@ -26,7 +26,7 @@ export function buildBlock(path, params, hash, program, inverse, loc) {
 export function buildElementModifier(path, params, hash, loc) {
   return {
     type: "ElementModifierStatement",
-    path: path,
+    path: buildPath(path),
     params: params || [],
     hash: hash || buildHash([]),
     loc: buildLoc(loc)
@@ -101,18 +101,22 @@ export function buildText(chars, loc) {
 export function buildSexpr(path, params, hash) {
   return {
     type: "SubExpression",
-    path: path,
+    path: buildPath(path),
     params: params || [],
     hash: hash || buildHash([])
   };
 }
 
 export function buildPath(original) {
-  return {
-    type: "PathExpression",
-    original: original,
-    parts: original.split('.')
-  };
+  if (typeof original === 'string') {
+    return {
+      type: "PathExpression",
+      original: original,
+      parts: original.split('.')
+    };
+  } else {
+    return original;
+  }
 }
 
 export function buildString(value) {

--- a/packages/htmlbars-syntax/lib/traversal/errors.js
+++ b/packages/htmlbars-syntax/lib/traversal/errors.js
@@ -1,0 +1,26 @@
+function TraversalError(message, node, parent, key) {
+  this.name = "TraversalError";
+  this.message = message;
+  this.node = node;
+  this.parent = parent;
+  this.key = key;
+}
+
+TraversalError.prototype = Object.create(Error.prototype);
+TraversalError.prototype.constructor = TraversalError;
+
+export default TraversalError;
+
+export function cannotRemoveNode(node, parent, key) {
+  return new TraversalError(
+    "Cannot remove a node unless it is part of an array",
+    node, parent, key
+  );
+}
+
+export function cannotReplaceNode(node, parent, key) {
+  return new TraversalError(
+    "Cannot replace a node with multiple nodes unless it is part of an array",
+    node, parent, key
+  );
+}

--- a/packages/htmlbars-syntax/lib/traversal/traverse.js
+++ b/packages/htmlbars-syntax/lib/traversal/traverse.js
@@ -1,49 +1,95 @@
 import visitorKeys from '../types/visitor-keys';
+import {
+  cannotRemoveNode,
+  cannotReplaceNode,
+} from './errors';
 
-function visitNode(node, visitor) {
+function visitNode(visitor, node) {
   let handler = visitor[node.type] || visitor.All;
+  let result;
 
   if (handler && handler.enter) {
-    handler.enter.call(null, node);
+    result = handler.enter.call(null, node);
   }
 
-  visitChildNodes(node, visitor);
+  if (result === undefined) {
+    let keys = visitorKeys[node.type];
 
-  if (handler && handler.exit) {
-    handler.exit.call(null, node);
+    for (let i = 0; i < keys.length; i++) {
+      visitKey(visitor, node, keys[i]);
+    }
+
+    if (handler && handler.exit) {
+      result = handler.exit.call(null, node);
+    }
   }
+
+  return result;
 }
 
-function visitChildNodes(node, visitor) {
-  let keys = visitorKeys[node.type];
+function visitKey(visitor, node, key) {
+  let value = node[key];
+  if (!value) { return; }
 
-  for (let i = 0; i < keys.length; i++) {
-    let child = node[keys[i]];
-    if (child) {
-      if (Array.isArray(child)) {
-        visitArrayOfNodes(child, visitor);
-      } else {
-        visitNode(child, visitor);
-      }
+  if (Array.isArray(value)) {
+    visitArray(visitor, value);
+  } else {
+    let result = visitNode(visitor, value);
+    if (result !== undefined) {
+      assignKey(node, key, result); 
     }
   }
 }
 
-function visitArrayOfNodes(nodes, visitor) {
-  for (let i = 0; i < nodes.length; i++) {
-    visitNode(nodes[i], visitor);
+function visitArray(visitor, array) {
+  for (let i = 0; i < array.length; i++) {
+    let result = visitNode(visitor, array[i]);
+    if (result !== undefined) {
+      i += spliceArray(array, i, result) - 1;
+    }
+  }
+}
+
+function assignKey(node, key, result) {
+  if (result === null) {
+    throw cannotRemoveNode(node[key], node, key);
+  } else if (Array.isArray(result)) {
+    if (result.length === 1) {
+      node[key] = result[0];
+    } else {
+      if (result.length === 0) {
+        throw cannotRemoveNode(node[key], node, key);
+      } else {
+        throw cannotReplaceNode(node[key], node, key);
+      }
+    }
+  } else {
+    node[key] = result;
+  }
+}
+
+function spliceArray(array, index, result) {
+  if (result === null) {
+    array.splice(index, 1);
+    return 0;
+  } else if (Array.isArray(result)) {
+    array.splice(index, 1, ...result);
+    return result.length;
+  } else {
+    array.splice(index, 1, result);
+    return 1;
   }
 }
 
 export default function traverse(node, visitor) {
-  visitNode(node, normalizeVisitor(visitor));
+  visitNode(normalizeVisitor(visitor), node);
 }
 
-function normalizeVisitor(visitor) {
+export function normalizeVisitor(visitor) {
   let normalizedVisitor = {};
 
   for (let type in visitor) {
-    let handler = visitor[type];
+    let handler = visitor[type] || visitor.All;
 
     if (typeof handler === 'object') {
       normalizedVisitor[type] = {

--- a/packages/htmlbars-syntax/lib/traversal/traverse.js
+++ b/packages/htmlbars-syntax/lib/traversal/traverse.js
@@ -1,7 +1,7 @@
 import visitorKeys from '../types/visitor-keys';
 
 function visitNode(node, visitor) {
-  let handler = visitor[node.type];
+  let handler = visitor[node.type] || visitor.All;
 
   if (handler && handler.enter) {
     handler.enter.call(null, node);

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -1,59 +1,9 @@
 import { parse as handlebarsParse } from "../htmlbars-syntax/handlebars/compiler/base";
 import { parse } from "../htmlbars-syntax";
-
 import b from "../htmlbars-syntax/builders";
+import { astEqual } from "./support";
 
 QUnit.module("[htmlbars-syntax] HTML-based compiler (AST)");
-
-function normalizeNode(obj) {
-  if (obj && typeof obj === 'object') {
-    var newObj;
-    if (obj.splice) {
-      newObj = new Array(obj.length);
-
-      for (var i = 0; i < obj.length; i++) {
-        newObj[i] = normalizeNode(obj[i]);
-      }
-    } else {
-      newObj = {};
-
-      for (var key in obj) {
-        if (obj.hasOwnProperty(key)) {
-          newObj[key] = normalizeNode(obj[key]);
-        }
-      }
-
-      if (newObj.type) {
-        newObj._type = newObj.type;
-        delete newObj.type;
-      }
-
-      newObj.loc = null;
-    }
-    return newObj;
-  } else {
-    return obj;
-  }
-
-}
-
-function astEqual(actual, expected, message) {
-  // Perform a deepEqual but recursively remove the locInfo stuff
-  // (e.g. line/column information about the compiled template)
-  // that we don't want to have to write into our test cases.
-
-  if (typeof actual === 'string') {
-    actual = parse(actual);
-  }
-  if (typeof expected === 'string') {
-    expected = parse(expected);
-  }
-
-  actual = normalizeNode(actual);
-  expected = normalizeNode(expected);
-
-  deepEqual(actual, expected, message);
-}
 
 test("a simple piece of content", function() {
   var t = 'some content';

--- a/packages/htmlbars-syntax/tests/support.js
+++ b/packages/htmlbars-syntax/tests/support.js
@@ -1,0 +1,46 @@
+import { parse } from '../htmlbars-syntax';
+
+function normalizeNode(obj) {
+  if (obj && typeof obj === 'object') {
+    var newObj;
+    if (obj.splice) {
+      newObj = new Array(obj.length);
+
+      for (var i = 0; i < obj.length; i++) {
+        newObj[i] = normalizeNode(obj[i]);
+      }
+    } else {
+      newObj = {};
+
+      for (var key in obj) {
+        if (obj.hasOwnProperty(key)) {
+          newObj[key] = normalizeNode(obj[key]);
+        }
+      }
+
+      if (newObj.type) {
+        newObj._type = newObj.type;
+        delete newObj.type;
+      }
+
+      delete newObj.loc;
+    }
+    return newObj;
+  } else {
+    return obj;
+  }
+}
+
+export function astEqual(actual, expected, message) {
+  if (typeof actual === 'string') {
+    actual = parse(actual);
+  }
+  if (typeof expected === 'string') {
+    expected = parse(expected);
+  }
+
+  actual = normalizeNode(actual);
+  expected = normalizeNode(expected);
+
+  deepEqual(actual, expected, message);
+}

--- a/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.js
+++ b/packages/htmlbars-syntax/tests/traversal/manipulating-node-test.js
@@ -1,0 +1,221 @@
+import { astEqual } from '../support';
+import {
+  parse,
+  traverse,
+  builders as b
+} from '../../htmlbars-syntax';
+import {
+  cannotRemoveNode,
+  cannotReplaceNode,
+} from '../../htmlbars-syntax/traversal/errors';
+
+QUnit.module('[htmlbars-syntax] Traversal - manipulating');
+
+['enter', 'exit'].forEach(eventName => {
+  QUnit.test(`[${eventName}] Replacing self in a key (returning null)`, assert => {
+    let ast = parse(`<x y={{z}} />`);
+    let attr = ast.body[0].attributes[0];
+
+    assert.throws(() => {
+      traverse(ast, {
+        MustacheStatement: {
+          [eventName](node) {
+            if (node.path.parts[0] === 'z') {
+              return null;
+            }
+          }
+        }
+      });
+    }, cannotRemoveNode(attr.value, attr, 'value'));
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in a key (returning an empty array)`, assert => {
+    let ast = parse(`<x y={{z}} />`);
+    let attr = ast.body[0].attributes[0];
+
+    assert.throws(() => {
+      traverse(ast, {
+        MustacheStatement: {
+          [eventName](node) {
+            if (node.path.parts[0] === 'z') {
+              return [];
+            }
+          }
+        }
+      });
+    }, cannotRemoveNode(attr.value, attr, 'value'));
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in a key (returning a node)`, () => {
+    let ast = parse(`<x y={{z}} />`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'z') {
+            return b.mustache('a');
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `<x y={{a}} />`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in a key (returning an array with a single node)`, () => {
+    let ast = parse(`<x y={{z}} />`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'z') {
+            return [b.mustache('a')];
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `<x y={{a}} />`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in a key (returning an array with multiple nodes)`, assert => {
+    let ast = parse(`<x y={{z}} />`);
+    let attr = ast.body[0].attributes[0];
+
+    assert.throws(() => {
+      traverse(ast, {
+        MustacheStatement: {
+          [eventName](node) {
+            if (node.path.parts[0] === 'z') {
+              return [
+                b.mustache('a'),
+                b.mustache('b'),
+                b.mustache('c')
+              ];
+            }
+          }
+        }
+      });
+    }, cannotReplaceNode(attr.value, attr, 'value'));
+  });
+
+
+  QUnit.test(`[${eventName}] Replacing self in an array (returning null)`, () => {
+    let ast = parse(`{{x}}{{y}}{{z}}`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'y') {
+            return null;
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `{{x}}{{z}}`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in an array (returning an empty array)`, () => {
+    let ast = parse(`{{x}}{{y}}{{z}}`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'y') {
+            return [];
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `{{x}}{{z}}`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in an array (returning a node)`, () => {
+    let ast = parse(`{{x}}{{y}}{{z}}`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'y') {
+            return b.mustache('a');
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `{{x}}{{a}}{{z}}`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in an array (returning an array with a single node)`, () => {
+    let ast = parse(`{{x}}{{y}}{{z}}`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'y') {
+            return [b.mustache('a')];
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `{{x}}{{a}}{{z}}`);
+  });
+
+  QUnit.test(`[${eventName}] Replacing self in an array (returning an array with multiple nodes)`, () => {
+    let ast = parse(`{{x}}{{y}}{{z}}`);
+
+    traverse(ast, {
+      MustacheStatement: {
+        [eventName](node) {
+          if (node.path.parts[0] === 'y') {
+            return [
+              b.mustache('a'),
+              b.mustache('b'),
+              b.mustache('c')
+            ];
+          }
+        }
+      }
+    });
+
+    astEqual(ast, `{{x}}{{a}}{{b}}{{c}}{{z}}`);
+  });
+});
+
+
+QUnit.module('[htmlbars-syntax] Traversal - manipulating (edge cases)');
+
+QUnit.test('Inside of a block', () => {
+  let ast = parse(`{{y}}{{#w}}{{x}}{{y}}{{z}}{{/w}}`);
+
+  traverse(ast, {
+    MustacheStatement(node) {
+      if (node.path.parts[0] === 'y') {
+        return [
+          b.mustache('a'),
+          b.mustache('b'),
+          b.mustache('c')
+        ];
+      }
+    }
+  });
+
+  astEqual(ast, `{{a}}{{b}}{{c}}{{#w}}{{x}}{{a}}{{b}}{{c}}{{z}}{{/w}}`);
+});
+
+QUnit.test('Exit event is not triggered if the node is replaced during the enter event', assert => {
+  let ast = parse(`{{x}}`);
+  let didExit = false;
+
+  traverse(ast, {
+    MustacheStatement: {
+      enter() { return b.mustache('y'); },
+      exit() { didExit = true; }
+    }
+  });
+
+  assert.strictEqual(didExit, false);
+});

--- a/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
@@ -1,19 +1,14 @@
 import { parse, traverse } from '../../htmlbars-syntax';
-import visitorKeys from '../../htmlbars-syntax/types/visitor-keys';
-
-let actualTraversal;
-let assertionVisitor = {};
-
-for (let key in visitorKeys) {
-  assertionVisitor[key] = {
-    enter(node) { actualTraversal.push(['enter', node]); },
-    exit(node) { actualTraversal.push(['exit',  node]); }
-  };
-}
 
 function traversalEqual(node, expectedTraversal) {
-  actualTraversal = [];
-  traverse(node, assertionVisitor);
+  let actualTraversal = [];
+
+  traverse(node, {
+    All: {
+      enter(node) { actualTraversal.push(['enter', node]); },
+      exit(node) { actualTraversal.push(['exit',  node]); }
+    }
+  });
 
   deepEqual(
     actualTraversal.map(a => `${a[0]}:${a[1].type}`),
@@ -30,8 +25,6 @@ function traversalEqual(node, expectedTraversal) {
   }
 
   ok(nodesEqual, "Actual nodes match expected nodes");
-
-  actualTraversal = null;
 }
 
 QUnit.module('[htmlbars-syntax] Traversal - visiting');


### PR DESCRIPTION
You can now return `null`, a node or an array of nodes inside of the `enter` and `exit` events to replace the current node. Returning `null` is equivalent to returning an empty array. You can only replace a node with multiple nodes (or zero nodes) if it is part of an array.

If you return a replacement in the `enter` event then replacement's child nodes **will not** be visited (the user created the nodes, so there's no point) and moreover the `exit` event for the current node **will not** be called (this would just be confusing, since the node has been replaced possibly by multiple nodes).

Here is an illustrative example from the tests:

```js
QUnit.test('Inside of a block', () => {
  let ast = parse(`{{y}}{{#w}}{{x}}{{y}}{{z}}{{/w}}`);

  traverse(ast, {
    MustacheStatement(node) {
      if (node.path.parts[0] === 'y') {
        return [
          b.mustache('a'),
          b.mustache('b'),
          b.mustache('c')
        ];
      }
    }
  });

  astEqual(ast, `{{a}}{{b}}{{c}}{{#w}}{{x}}{{a}}{{b}}{{c}}{{z}}{{/w}}`);
});
```