### PR TITLE
Extend the visitor API to support keys

### DIFF
--- a/packages/htmlbars-syntax/lib/traversal/errors.js
+++ b/packages/htmlbars-syntax/lib/traversal/errors.js
@@ -24,3 +24,10 @@ export function cannotReplaceNode(node, parent, key) {
     node, parent, key
   );
 }
+
+export function cannotReplaceOrRemoveInKeyHandlerYet(node, key) {
+  return new TraversalError(
+    "Replacing and removing in key handlers is not yet supported.",
+    node, null, key
+  );
+}

--- a/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.js
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-keys-node-test.js
@@ -1,0 +1,99 @@
+import { parse, traverse } from '../../htmlbars-syntax';
+
+function traversalEqual(node, expectedTraversal) {
+  let actualTraversal = [];
+
+  traverse(node, {
+    All: {
+      enter(node) { actualTraversal.push(['enter', node]); },
+      exit(node) { actualTraversal.push(['exit',  node]); },
+      keys: {
+        All: {
+          enter(node, key) { actualTraversal.push([`enter:${key}`, node]); },
+          exit(node, key) { actualTraversal.push([`exit:${key}`,  node]); },
+        }
+      }
+    }
+  });
+
+  deepEqual(
+    actualTraversal.map(a => `${a[0]} ${a[1].type}`),
+    expectedTraversal.map(a => `${a[0]} ${a[1].type}`)
+  );
+
+  let nodesEqual = true;
+
+  for (let i = 0; i < actualTraversal.length; i++) {
+    if (actualTraversal[i][1] !== expectedTraversal[i][1]) {
+      nodesEqual = false;
+      break;
+    }
+  }
+
+  ok(nodesEqual, "Actual nodes match expected nodes");
+}
+
+QUnit.module('[htmlbars-syntax] Traversal - visiting keys');
+
+test('Blocks', function() {
+  let ast = parse(`{{#block param1 param2 key1=value key2=value}}<b></b><b></b>{{/block}}`);
+
+  traversalEqual(ast, [
+    ['enter',            ast],
+    ['enter:body',       ast],
+    ['enter',            ast.body[0]],
+    ['enter:path',       ast.body[0]],
+    ['enter',            ast.body[0].path],
+    ['exit',             ast.body[0].path],
+    ['exit:path',        ast.body[0]],
+    ['enter:params',     ast.body[0]],
+    ['enter',            ast.body[0].params[0]],
+    ['exit',             ast.body[0].params[0]],
+    ['enter',            ast.body[0].params[1]],
+    ['exit',             ast.body[0].params[1]],
+    ['exit:params',      ast.body[0]],
+    ['enter:hash',       ast.body[0]],
+    ['enter',            ast.body[0].hash],
+    ['enter:pairs',      ast.body[0].hash],
+    ['enter',            ast.body[0].hash.pairs[0]],
+    ['enter:value',      ast.body[0].hash.pairs[0]],
+    ['enter',            ast.body[0].hash.pairs[0].value],
+    ['exit',             ast.body[0].hash.pairs[0].value],
+    ['exit:value',       ast.body[0].hash.pairs[0]],
+    ['exit',             ast.body[0].hash.pairs[0]],
+    ['enter',            ast.body[0].hash.pairs[1]],
+    ['enter:value',      ast.body[0].hash.pairs[1]],
+    ['enter',            ast.body[0].hash.pairs[1].value],
+    ['exit',             ast.body[0].hash.pairs[1].value],
+    ['exit:value',       ast.body[0].hash.pairs[1]],
+    ['exit',             ast.body[0].hash.pairs[1]],
+    ['exit:pairs',       ast.body[0].hash],
+    ['exit',             ast.body[0].hash],
+    ['exit:hash',        ast.body[0]],
+    ['enter:program',    ast.body[0]],
+    ['enter',            ast.body[0].program],
+    ['enter:body',       ast.body[0].program],
+    ['enter',            ast.body[0].program.body[0]],
+    ['enter:attributes', ast.body[0].program.body[0]],
+    ['exit:attributes',  ast.body[0].program.body[0]],
+    ['enter:modifiers',  ast.body[0].program.body[0]],
+    ['exit:modifiers',   ast.body[0].program.body[0]],
+    ['enter:children',   ast.body[0].program.body[0]],
+    ['exit:children',    ast.body[0].program.body[0]],
+    ['exit',             ast.body[0].program.body[0]],
+    ['enter',            ast.body[0].program.body[1]],
+    ['enter:attributes', ast.body[0].program.body[1]],
+    ['exit:attributes',  ast.body[0].program.body[1]],
+    ['enter:modifiers',  ast.body[0].program.body[1]],
+    ['exit:modifiers',   ast.body[0].program.body[1]],
+    ['enter:children',   ast.body[0].program.body[1]],
+    ['exit:children',    ast.body[0].program.body[1]],
+    ['exit',             ast.body[0].program.body[1]],
+    ['exit:body',        ast.body[0].program],
+    ['exit',             ast.body[0].program],
+    ['exit:program',     ast.body[0]],
+    ['exit',             ast.body[0]],
+    ['exit:body',        ast],
+    ['exit',             ast]
+  ]);
+});

--- a/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
+++ b/packages/htmlbars-syntax/tests/traversal/visiting-node-test.js
@@ -11,8 +11,8 @@ function traversalEqual(node, expectedTraversal) {
   });
 
   deepEqual(
-    actualTraversal.map(a => `${a[0]}:${a[1].type}`),
-    expectedTraversal.map(a => `${a[0]}:${a[1].type}`)
+    actualTraversal.map(a => `${a[0]} ${a[1].type}`),
+    expectedTraversal.map(a => `${a[0]} ${a[1].type}`)
   );
 
   let nodesEqual = true;


### PR DESCRIPTION
You can now hook onto enter/exit events of individual visitor keys:

```js
traverse(ast, {
  MustacheStatement: {
    enter(node) { ... },
    exit(node) { ... },
    keys: {
      params: {
        enter(node, key) { ... },
        exit(node, key) { ... },
      },
      hash(node, key) { ... }
  }
}
```

The arguments `node`, `key` correspond to the current node and the current key being accessed on that node. The value is `node[key]`. In the example above, `node` is a `MustacheStatement` and `key` is `"params"` or `"hash"`. Typically you won't need to use the `key` argument unless you are sharing event handlers.