### PR TITLE
Preserve newlines that begin content statements

### DIFF
--- a/packages/htmlbars-syntax/lib/parser/handlebars-node-visitors.js
+++ b/packages/htmlbars-syntax/lib/parser/handlebars-node-visitors.js
@@ -109,7 +109,7 @@ export default {
     }
 
     this.tokenizer.line = this.tokenizer.line + changeLines;
-    this.tokenizer.tokenizePart(content.value);
+    this.tokenizer.tokenizePart(content.original);
     this.tokenizer.flushData();
   },
 

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -202,6 +202,18 @@ test("Simple embedded block helpers", function() {
   ]));
 });
 
+test("Multiline blocks preserve newlines", function() {
+  var t = "{{#each}}\n  <li>foo</li>\n{{/each}}";
+  ast = parse(t);
+  astEqual(t, b.program([
+    b.block(b.path('each'), [], b.hash(), b.program([
+      b.text('\n  '),
+      b.element('li', [], [], [b.text('foo')]),
+      b.text('\n')
+    ]))
+  ]));
+});
+
 test("Involved block helper", function() {
   var t = '<p>hi</p> content {{#testing shouldRender}}<p>Appears!</p>{{/testing}} more <em>content</em> here';
   astEqual(t, b.program([


### PR DESCRIPTION
@mmun this is currently causing issues in the recursive printer