### PR TITLE
[Bugfix] Adjusting issue #11727 from Ember.js that is relation related with htmlbars.

### DIFF
--- a/packages/htmlbars-syntax/lib/builders.js
+++ b/packages/htmlbars-syntax/lib/builders.js
@@ -96,6 +96,14 @@ export function buildText(chars, loc) {
   };
 }
 
+export function buildTextBoolean(chars, loc) {
+  return {
+    type: "TextNode",
+    chars: JSON.parse(chars),
+    loc: buildLoc(loc)
+  };
+}
+
 // Expressions
 
 export function buildSexpr(path, params, hash) {
@@ -228,6 +236,7 @@ export default {
   component: buildComponent,
   attr: buildAttr,
   text: buildText,
+  textBoolean: buildTextBoolean,
   sexpr: buildSexpr,
   path: buildPath,
   string: buildString,

--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -178,7 +178,28 @@ function assembleAttributeValue(parts, isQuoted, isDynamic, line) {
       }
     }
   } else {
-    return b.text((parts.length > 0) ? parts[0] : "");
+    return setAttributeValue(parts);
+  }
+}
+
+function isBoolean(value){
+  let isBool = false;
+  value = value.toString().toLowerCase();
+
+  isBool = value === 'true' || value === 'false' ? true : value;
+
+  return typeof isBool === 'boolean';
+  
+}
+
+function setAttributeValue(parts){
+  let part = (parts.length > 0) ? parts[0] : "";
+  
+  if(isBoolean(part)){
+    return b.textBoolean(part);
+  }
+  else{
+    return b.text(part);
   }
 }
 

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -456,3 +456,32 @@ test("allow {{undefined}} to be passed as a param", function() {
     b.mustache(b.path('foo'), [b.undefined()])
   ]));
 });
+
+test("allow boolean properties in a HTML component", function() {
+  var t = "<x-foo a=true c=false>{{a}}{{c}}</x-foo>";
+  astEqual(t, b.program([
+    b.component('x-foo', [
+      b.attr('a', b.textBoolean(true)),
+      b.attr('c', b.textBoolean(false))
+    ], b.program([
+      b.mustache(b.path('a')),
+      b.mustache(b.path('c'))
+    ]))
+  ]));
+});
+
+test("verify if property that receive a boolean as true in a HTML component will return a boolean as true", function() {
+  astEqual(b.component('x-foo', [
+      b.attr('a', true)
+    ], b.program([
+      b.text('a')
+    ])).attributes[0].value, true);
+});
+
+test("verify if property that receive a boolean as false in a HTML component will return a boolean as false", function() {
+  astEqual(b.component('x-foo', [
+      b.attr('a', false)
+    ], b.program([
+      b.text('a')
+    ])).attributes[0].value, false);
+});


### PR DESCRIPTION
Hello,

I'm correcting the bug #11727 from Ember.js that is related with HTMLBars. The bug happens when a component is created using angle brackets and a property receive a value as a boolean. The HTMLBars is not treating this value as a boolean.