### PR TITLE
Implement AST printer

### DIFF
--- a/packages/htmlbars-syntax/lib/generation/print.js
+++ b/packages/htmlbars-syntax/lib/generation/print.js
@@ -1,0 +1,176 @@
+export default function build(ast) {
+  if(!ast) {
+    return '';
+  }
+  const output = [];
+
+  switch(ast.type) {
+    case 'Program': {
+      const chainBlock = ast.chained && ast.body[0];
+      if(chainBlock) {
+        chainBlock.chained = true;
+      }
+      const body = buildEach(ast.body).join('');
+      output.push(body);
+    }
+    break;
+    case 'ElementNode':
+      output.push('<', ast.tag);
+      if(ast.attributes.length) {
+        output.push(' ', buildEach(ast.attributes).join(' '));
+      }
+      if(ast.modifiers.length) {
+        output.push(' ', buildEach(ast.modifiers).join(' '));
+      }
+      output.push('>');
+      output.push.apply(output, buildEach(ast.children));
+      output.push('</', ast.tag, '>');
+    break;
+    case 'AttrNode':
+      output.push(ast.name, '=');
+      const value = build(ast.value);
+      if(ast.value.type === 'TextNode') {
+        output.push('"', value, '"');
+      } else {
+        output.push(value);
+      }
+    break;
+    case 'ConcatStatement':
+      output.push('"');
+      ast.parts.forEach(function(node) {
+        if(node.type === 'StringLiteral') {
+          output.push(node.original);
+        } else {
+          output.push(build(node));
+        }
+      });
+      output.push('"');
+    break;
+    case 'TextNode':
+      output.push(ast.chars);
+    break;
+    case 'MustacheStatement': {
+      output.push(compactJoin(['{{', pathParams(ast), '}}']));
+    }
+    break;
+    case 'ElementModifierStatement': {
+      output.push(compactJoin(['{{', pathParams(ast), '}}']));
+    }
+    break;
+    case 'PathExpression':
+      output.push(ast.original);
+    break;
+    case 'SubExpression': {
+      output.push('(', pathParams(ast), ')');
+    }
+    break;
+    case 'BooleanLiteral':
+      output.push(ast.value ? 'true' : false);
+    break;
+    case 'BlockStatement': {
+      const lines = [];
+
+      if(ast.chained){
+        lines.push(['{{else ', pathParams(ast), '}}'].join(''));
+      }else{
+        lines.push(openBlock(ast));
+      }
+
+      lines.push(build(ast.program));
+
+      if(ast.inverse) {
+        if(!ast.inverse.chained){
+          lines.push('{{else}}');
+        }
+        lines.push(build(ast.inverse));
+      }
+
+      if(!ast.chained){
+        lines.push(closeBlock(ast));
+      }
+
+      output.push(lines.join(''));
+    }
+    break;
+    case 'PartialStatement': {
+      output.push(compactJoin(['{{>', pathParams(ast), '}}']));
+    }
+    break;
+    case 'CommentStatement': {
+      output.push(compactJoin(['<!--', ast.value, '-->']));
+    }
+    break;
+    case 'StringLiteral': {
+      output.push(`"${ast.value}"`);
+    }
+    break;
+    case 'NumberLiteral': {
+      output.push(ast.value);
+    }
+    break;
+    case 'UndefinedLiteral': {
+      output.push('undefined');
+    }
+    break;
+    case 'NullLiteral': {
+      output.push('null');
+    }
+    break;
+    case 'Hash': {
+      output.push(ast.pairs.map(function(pair) {
+        return build(pair);
+      }).join(' '));
+    }
+    break;
+    case 'HashPair': {
+      output.push(`${ast.key}=${build(ast.value)}`);
+    }
+    break;
+  }
+  return output.join('');
+}
+
+function compact(array) {
+  const newArray = [];
+  array.forEach(function(a) {
+    if(typeof(a) !== 'undefined' && a !== null && a !== '') {
+      newArray.push(a);
+    }
+  });
+  return newArray;
+}
+
+function buildEach(asts) {
+  const output = [];
+  asts.forEach(function(node) {
+    output.push(build(node));
+  });
+  return output;
+}
+
+function pathParams(ast) {
+  const name = build(ast.name);
+  const path = build(ast.path);
+  const params = buildEach(ast.params).join(' ');
+  const hash = build(ast.hash);
+  return compactJoin([name, path, params, hash], ' ');
+}
+
+function compactJoin(array, delimiter) {
+  return compact(array).join(delimiter || '');
+}
+
+function blockParams(block) {
+  const params = block.program.blockParams;
+  if(params.length) {
+    return ` as |${params.join(',')}|`;
+  }
+}
+
+function openBlock(block) {
+  return ['{{#', pathParams(block), blockParams(block), '}}'].join('');
+}
+
+function closeBlock(block) {
+  return ['{{/', build(block.path), '}}'].join('');
+}

--- a/packages/htmlbars-syntax/lib/main.js
+++ b/packages/htmlbars-syntax/lib/main.js
@@ -1,11 +1,13 @@
 import builders from "./htmlbars-syntax/builders";
 import parse from "./htmlbars-syntax/parser";
+import print from "./htmlbars-syntax/generation/print";
 import traverse from "./htmlbars-syntax/traversal/traverse";
 import Walker from "./htmlbars-syntax/traversal/walker";
 
 export {
   builders,
   parse,
+  print,
   traverse,
   Walker
 };

--- a/packages/htmlbars-syntax/tests/generation/print-test.js
+++ b/packages/htmlbars-syntax/tests/generation/print-test.js
@@ -1,0 +1,101 @@
+import { parse, print, builders } from '../../htmlbars-syntax';
+
+const b = builders;
+
+function printEqual(template) {
+  const ast = parse(template);
+  equal(print(ast), template);
+}
+
+QUnit.module('[htmlbars-syntax] Generation - printing');
+
+test('ElementNode: tag', function() {
+  printEqual('<h1></h1>');
+});
+
+test('ElementNode: nested tags with indent', function() {
+  printEqual('<div>\n  <p>Test</p>\n</div>');
+});
+
+test('ElementNode: attributes', function() {
+  printEqual('<h1 class="foo" id="title"></h1>');
+});
+
+test('TextNode: chars', function() {
+  printEqual('<h1>Test</h1>');
+});
+
+test('MustacheStatement: slash in path', function() {
+  printEqual('{{namespace/foo "bar" baz="qux"}}');
+});
+
+test('MustacheStatement: path', function() {
+  printEqual('<h1>{{model.title}}</h1>');
+});
+
+test('MustacheStatement: StringLiteral param', function() {
+  printEqual('<h1>{{link-to "Foo"}}</h1>');
+});
+
+test('MustacheStatement: hash', function() {
+  printEqual('<h1>{{link-to "Foo" class="bar"}}</h1>');
+});
+
+test('MustacheStatement: as element attribute', function() {
+  printEqual('<h1 class={{if foo "foo" "bar"}}>Test</h1>');
+});
+
+test('MustacheStatement: as element attribute with path', function() {
+  printEqual('<h1 class={{color}}>Test</h1>');
+});
+
+test('ConcatStatement: in element attribute string', function() {
+  printEqual('<h1 class="{{if active "active" "inactive"}} foo">Test</h1>');
+});
+
+test('ElementModifierStatement', function() {
+  printEqual('<p {{action "activate"}} {{someting foo="bar"}}>Test</p>');
+});
+
+test('PartialStatement', function() {
+  printEqual('<p>{{>something "param"}}</p>');
+});
+
+test('SubExpression', function() {
+  printEqual('<p>{{my-component submit=(action (mut model.name) (full-name model.firstName "Smith"))}}</p>');
+});
+
+test('BlockStatement: multiline', function() {
+  printEqual('<ul>{{#each foos as |foo|}}\n  {{foo}}\n{{/each}}</ul>');
+});
+
+test('BlockStatement: inline', function() {
+  printEqual('{{#if foo}}<p>{{foo}}</p>{{/if}}');
+});
+
+test('UndefinedLiteral', function() {
+  const ast = b.program([b.mustache(b['undefined']())]);
+  equal(print(ast), '{{undefined}}');
+});
+
+test('NumberLiteral', function() {
+  const ast = b.program([
+    b.mustache('foo', null,
+      b.hash([b.pair('bar', b.number(5))])
+    )
+  ]);
+  equal(print(ast), '{{foo bar=5}}');
+});
+
+test('BooleanLiteral', function() {
+  const ast = b.program([
+    b.mustache('foo', null,
+      b.hash([b.pair('bar', b.boolean(true))])
+    )
+  ]);
+  equal(print(ast), '{{foo bar=true}}');
+});
+
+test('HTML comment', function() {
+  printEqual('<!-- foo -->');
+});


### PR DESCRIPTION
This is the most basic AST printer. It does **not** reproduce the exact source that generated the AST.

That is to say, these tests don't always pass:
`equal(print(parse(template)), template)`
`deepEqual(parse(print(ast)), ast)`

Currently, all statements and expressions are handled with the exception of comments, so the new source will have the same semantic meaning. However, certain formatting is lost.

Formatting:
- [x] newlines*
- [x] tabs
- [x] arbitrary indent sizes
- [x] blank lines
- [ ] newlines after opening or closing a block expression (seems to be a Handlebars issue)
- [ ] newlines between element attributes
- [ ] newlines between mustache attributes
- [ ] arbitrary spacing between element tag, attributes, and angle brackets
- [ ] arbitrary spacing between mustache path, params, hash, and attributes

Statements:
- [ ] Handlebars comment (stripped out of AST by Handlebars)