### PR TITLE
Fix issue with duplicate keys and last item.

### DIFF
--- a/packages/htmlbars-compiler/tests/diffing-test.js
+++ b/packages/htmlbars-compiler/tests/diffing-test.js
@@ -80,3 +80,18 @@ test("Morph order is preserved when rerendering with duplicate keys", function()
   equalTokens(result.fragment, `<ul><li>B1</li><li>A2</li></ul>`);
   deepEqual(getNames(), ['B1', 'A1']);
 });
+
+test("duplicate keys are allowed when duplicate is last morph", function() {
+  var template = compile(`<ul>{{#each items as |item|}}<li>{{item.name}}</li>{{/each}}</ul>`);
+
+  let a1 = { key: "a", name: "A1" };
+  let a2 = { key: "a", name: "A2" };
+
+  var result = template.render({ items: [ ] }, env);
+
+  result.rerender(env, { items: [ a1 ] });
+  equalTokens(result.fragment, `<ul><li>A1</li></ul>`);
+
+  result.rerender(env, { items: [a1, a2] });
+  equalTokens(result.fragment, `<ul><li>A1</li><li>A2</li></ul>`);
+});

--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -227,7 +227,7 @@ function yieldItem(template, env, parentScope, morph, renderState, visitor) {
     let handledMorphs = renderState.handledMorphs;
     let key;
 
-    if (handledMorphs[_key]) {
+    if (_key in handledMorphs) {
       // In this branch we are dealing with a duplicate key. The strategy
       // is to take the original key and append a counter to it that is
       // incremented every time the key is reused. In order to greatly


### PR DESCRIPTION
We are using `renderState.handledMorphs` as a way to know if a given key is duplicated or not (if it is duplicated we use a binning strategy to prevent errors), but we were setting `handleMorphs[key]` to `null` when the given morph was the last item in the list.

The fix is to keep `renderAndCleanup` and `yieldItem` using the same mechanism to know of the handled morphs (both should check via `key in handledMorphs`).

This is the fix for https://github.com/emberjs/ember.js/pull/11949.