### PR TITLE
[BUGFIX] add `autocorrect` attr override because Mobile Safari hates us

### DIFF
--- a/packages/dom-helper/lib/prop.js
+++ b/packages/dom-helper/lib/prop.js
@@ -53,7 +53,11 @@ var ATTR_OVERRIDES = {
     // Some version of IE (like IE9) actually throw an exception
     // if you set input.type = 'something-unknown'
     type: true,
-    form: true
+    form: true,
+    // Chrome 46.0.2464.0: 'autocorrect' in document.createElement('input') === false
+    // Safari 8.0.7: 'autocorrect' in document.createElement('input') === false
+    // Mobile Safari (iOS 8.4 simulator): 'autocorrect' in document.createElement('input') === true
+    autocorrect: true
   },
 
   // element.form is actually a legitimate readOnly property, that is to be

--- a/packages/dom-helper/tests/prop-test.js
+++ b/packages/dom-helper/tests/prop-test.js
@@ -3,7 +3,7 @@ import { normalizeProperty } from 'dom-helper/prop';
 QUnit.module('dom-helper prop');
 
 test('type.attr, for element props that for one reason or another need to be treated as attrs', function() {
-  expect(12);
+  expect(13);
 
   [
     { tagName: 'TEXTAREA', key: 'form' },
@@ -11,6 +11,7 @@ test('type.attr, for element props that for one reason or another need to be tre
     { tagName: 'INPUT',    key: 'type' },
     { tagName: 'INPUT',    key: 'list' },
     { tagName: 'INPUT',    key: 'form' },
+    { tagName: 'INPUT',    key: 'autocorrect' },
     { tagName: 'OPTION',   key: 'form' },
     { tagName: 'INPUT',    key: 'form' },
     { tagName: 'BUTTON',   key: 'form' },


### PR DESCRIPTION
fixes emberjs/ember.js#11869, Cc/ @stefanpenner 