### PR TITLE
Revert "Upgrade to ember-cli 1.13"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "broccoli-string-replace": "~0.0.2",
     "broccoli-uglify-js": "~0.1.3",
     "chalk": "~0.4.0",
-    "ember-cli": "^1.13.0",
+    "ember-cli": "^0.2.7",
     "ember-cli-release": "^0.2.2",
     "ember-cli-sauce": "^1.3.0",
     "emberjs-build": "0.2.1",


### PR DESCRIPTION
This reverts commit 9bedd3ce3e1b756fcdec1669474e1ab547d00b87.

This is causing the build to fail, see https://travis-ci.org/tildeio/htmlbars/builds/75021028