### PR TITLE
Properly visit MorphLists in visitChildren.

### DIFF
--- a/packages/htmlbars-compiler/tests/dirtying-test.js
+++ b/packages/htmlbars-compiler/tests/dirtying-test.js
@@ -462,6 +462,34 @@ test("Pruned render nodes invoke a cleanup hook when replaced", function() {
   strictEqual(destroyedRenderNode.lastValue, 'Nothing', "The correct render node is passed in");
 });
 
+test("MorphLists in childNodes are properly cleared", function() {
+  var object = {
+    condition: true,
+    falsy: "Nothing",
+    list: [
+      { key: "1", word: 'Hello' },
+      { key: "2", word: 'World' }
+    ]
+  };
+  var template = compile('<div>{{#if condition}}{{#each list as |item|}}<p>{{item.word}}</p>{{/each}}{{else}}<p>{{falsy}}</p>{{/if}}</div>');
+
+  var result = template.render(object, env);
+
+  equalTokens(result.fragment, "<div><p>Hello</p><p>World</p></div>");
+
+  object.condition = false;
+  result.rerender();
+
+  equalTokens(result.fragment, "<div><p>Nothing</p></div>");
+
+  strictEqual(destroyedRenderNodeCount, 5, "cleanup hook was invoked for each morph");
+
+  object.condition = true;
+  result.rerender();
+
+  strictEqual(destroyedRenderNodeCount, 6, "cleanup hook was invoked again");
+});
+
 test("Pruned render nodes invoke a cleanup hook when cleared", function() {
   var object = { condition: true, value: 'hello world' };
   var template = compile('<div>{{#if condition}}<p>{{value}}</p>{{/if}}</div>');

--- a/packages/htmlbars-util/lib/morph-utils.js
+++ b/packages/htmlbars-util/lib/morph-utils.js
@@ -12,17 +12,23 @@ export function visitChildren(nodes, callback) {
     if (node.childNodes) {
       nodes.push.apply(nodes, node.childNodes);
     } else if (node.firstChildMorph) {
-      var current = node.firstChildMorph;
+      let current = node.firstChildMorph;
 
       while (current) {
         nodes.push(current);
         current = current.nextMorph;
       }
     } else if (node.morphList) {
-      nodes.push(node.morphList);
+      let current = node.morphList.firstChildMorph;
+
+      while (current) {
+        nodes.push(current);
+        current = current.nextMorph;
+      }
     }
   }
 }
+
 
 export function validateChildMorphs(env, morph, visitor) {
   var morphList = morph.morphList;


### PR DESCRIPTION
`visitChildren` is used internally to visit all `Morph`'s and call a callback on each one found.  The most common usage of `visitChildren` in HTMLBars itself is for clearing morphs before rendering a new template.

Prior to this change, if we encounter a node with `morphList` we:

* add the `morphList` to the list of nodes to traverse
* call the provided callback
* traverse the `MorphList` and add all morphs found there to the list of
  morphs to call the callback on

In general that is fine, except when the callback itself (in step 2 above) is mutating the `morph` and preventing the `MorphList` from being traversed. This is the case when changing an `{{if}}` with a `{{each}}` from the template to the inverse block, in that case the callback is calling `MorphList#clear()` which nullifies the `MorphList` but does not call the various hooks (`didDestroyNode` specifically) so any morphs would be leaked.

This change tweaks `visitChildren` to unroll a `MorphList` upon encountering it (instead of waiting util after the callback has been called on it). The included test demonstrates the memory leak that was occurring in Ember and that it is properly fixed.