### PR TITLE
test to show that stripping whitespace after comments is possible

### DIFF
--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -347,6 +347,13 @@ test("Stripping - removes unnecessary text nodes", function() {
   ]));
 });
 
+test("Stripping - comments", function() {
+  var t = "{{!~}}\n  <li> foo </li>{{!~}}\n  ";
+  astEqual(t, b.program([
+    b.element('li', [], [], [b.text(' foo ')])
+  ]));
+});
+
 // TODO: Make these throw an error.
 //test("Awkward mustache in unquoted attribute value", function() {
 //  var t = "<div class=a{{foo}}></div>";


### PR DESCRIPTION
Adding `{{!~}}` to the end of a line in a htmlbars template file allows suppressing whitespace between that comment and the first non-whitespace character on the next line.

In my case this is useful when converting templates created in emblem (which by default suppresses whitespace) to htmlbars, without needing to manually squish all the dom tags together.

This behavior wasn't documented or tested anywhere.  Hence this PR.

related: https://github.com/tildeio/htmlbars/issues/305