### PR TITLE
Fix htmlbars-runtime import paths

### DIFF
--- a/packages/htmlbars-runtime/lib/main.js
+++ b/packages/htmlbars-runtime/lib/main.js
@@ -1,13 +1,13 @@
 import hooks from './htmlbars-runtime/hooks';
 import render from './htmlbars-runtime/render';
 import { manualElement } from './htmlbars-runtime/render';
-import { validateChildMorphs, visitChildren } from "../htmlbars-util/morph-utils";
-import { blockFor, clearMorph } from "../htmlbars-util/template-utils";
+import { validateChildMorphs, visitChildren } from "./htmlbars-util/morph-utils";
+import { blockFor, clearMorph } from "./htmlbars-util/template-utils";
 import {
   hostBlock,
   continueBlock,
   hostYieldWithShadowTemplate
-} from 'htmlbars-runtime/hooks';
+} from './htmlbars-runtime/hooks';
 
 
 var internal = {


### PR DESCRIPTION
I was trying to require the htmlbars-runtime package as a CommonJS module, but I kept receiving dependency errors.

On closer inspection, it looks like the import paths in `packages/htmlbars-runtime/lib/main.js` were inconsistent.

This PR should fix the module for use in CommonJS projects – I've tested the build and all seems fine, but let me know if there are any problems.