### PR TITLE
[FEATURE] Add contextual component syntax

### DIFF
--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -99,7 +99,7 @@ export default {
     element.loc.end.line = this.tokenizer.line;
     element.loc.end.column = this.tokenizer.column;
 
-    if (disableComponentGeneration || element.tag.indexOf("-") === -1) {
+    if (disableComponentGeneration || cannotBeComponent(element.tag)) {
       appendChild(parent, element);
     } else {
       let program = b.program(element.children);
@@ -200,6 +200,11 @@ function assembleConcatenatedValue(parts) {
   }
 
   return b.concat(parts);
+}
+
+function cannotBeComponent(tagName) {
+  return tagName.indexOf("-") === -1 &&
+      tagName.indexOf(".") === -1;
 }
 
 function validateStartTag(tag, tokenizer) {

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -430,6 +430,57 @@ test("Components with disableComponentGeneration === false", function() {
   ]));
 });
 
+test("Contextual components", function() {
+  var t = "<x.foo a=b c='d' e={{f}} id='{{bar}}' class='foo-{{bar}}'>{{a}}{{b}}c{{d}}</x.foo>{{e}}";
+  astEqual(t, b.program([
+    b.component('x.foo', [
+      b.attr('a', b.text('b')),
+      b.attr('c', b.text('d')),
+      b.attr('e', b.mustache(b.path('f'))),
+      b.attr('id', b.concat([ b.path('bar') ])),
+      b.attr('class', b.concat([ b.string('foo-'), b.path('bar') ]))
+    ], b.program([
+      b.mustache(b.path('a')),
+      b.mustache(b.path('b')),
+      b.text('c'),
+      b.mustache(b.path('d'))
+    ])),
+    b.mustache(b.path('e'))
+  ]));
+});
+
+test("Contextual components with disableComponentGeneration", function() {
+  var t = "begin <x.foo>content</x.foo> finish";
+  var actual = parse(t, {
+    disableComponentGeneration: true
+  });
+
+  astEqual(actual, b.program([
+    b.text("begin "),
+    b.element("x.foo", [], [], [
+      b.text("content")
+    ]),
+    b.text(" finish")
+  ]));
+});
+
+test("Contextual components with disableComponentGeneration === false", function() {
+  var t = "begin <x.foo>content</x.foo> finish";
+  var actual = parse(t, {
+    disableComponentGeneration: false
+  });
+
+  astEqual(actual, b.program([
+    b.text("begin "),
+    b.component("x.foo", [],
+      b.program([
+        b.text("content")
+      ])
+    ),
+    b.text(" finish")
+  ]));
+});
+
 test("an HTML comment", function() {
   var t = 'before <!-- some comment --> after';
   astEqual(t, b.program([


### PR DESCRIPTION
HTMLBars need to be able to generate components with syntax `my.comp` for
implementing contexual components.

emberjs/ember.js#12617