### PR TITLE
[BUGFIX beta] Range redirection

### DIFF
--- a/packages/htmlbars-runtime/lib/hooks.js
+++ b/packages/htmlbars-runtime/lib/hooks.js
@@ -835,7 +835,7 @@ export function partial(renderNode, env, scope, path) {
   that represents a range of content with a value.
 */
 export function range(morph, env, scope, path, value, visitor) {
-  if (handleRedirect(morph, env, scope, path, [value], {}, null, null, visitor)) {
+  if (handleRedirect(morph, env, scope, path, [], {}, null, null, visitor)) {
     return;
   }
 

--- a/packages/htmlbars-runtime/tests/hooks-test.js
+++ b/packages/htmlbars-runtime/tests/hooks-test.js
@@ -85,3 +85,24 @@ test("createChildScope hook creates a new object for `blocks`", function() {
   strictEqual(scope.blocks.notInherited, undefined);
   strictEqual(child.blocks.notInherited, childBlock);
 });
+
+test("range redirect sends empty test", function() {
+  // For a redirect to component
+  let oldComponentHook = env.hooks.component;
+  let oldClassify = env.hooks.classify;
+
+  env.hooks.component = function(morph, env, scope, path, params) {
+    equal(params.length, 0, 'params is empty');
+  };
+  env.hooks.classify = function() {
+    return 'component';
+  };
+
+  // Test body
+  let scope = env.hooks.createFreshScope();
+
+  env.hooks.range(null, env, scope, 'component-path', [], {});
+
+  env.hooks.classify = oldClassify;
+  env.hooks.component = oldComponentHook;
+});


### PR DESCRIPTION
When an `range` calls `handleRedirect` it sets the `params` to an array
containing its value. This causes problems with contextual components called
with dot syntax.

If a contextual component is called with dot syntax and any kind of arguments
(either `params` and `attrs`) it gets compiled to `inline`. But when called
without any of them (`{{contextual.my-component}}`), it gets compiled to
a `range`.

The `range` calls to `handleRedirect` but sets `params` to be `[value]` instead
of an empty array, causing `positionalParams` to receive the wrong value.

Fixes emberjs/ember.js#12717