### PR TITLE
[BUGFIX beta] Allow unquoted attributes before the end of a self-closing tag

### DIFF
--- a/packages/htmlbars-compiler/tests/html-compiler-test.js
+++ b/packages/htmlbars-compiler/tests/html-compiler-test.js
@@ -141,7 +141,7 @@ test("Unquoted attribute value with multiple nodes throws an exception", functio
     return new Error(
       `An unquoted attribute value must be a string or a mustache, ` +
       `preceeded by whitespace or a '=' character, and ` +
-      `followed by whitespace or a '>' character (on line ${line})`
+      `followed by whitespace, a '>' character or a '/>' (on line ${line})`
     );
   }
 });

--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -169,13 +169,13 @@ function assembleAttributeValue(parts, isQuoted, isDynamic, line) {
     if (isQuoted) {
       return assembleConcatenatedValue(parts);
     } else {
-      if (parts.length === 1) {
+      if (parts.length === 1 || (parts.length === 2 && parts[1] === '/')) {
         return parts[0];
       } else {
         throw new Error(
           `An unquoted attribute value must be a string or a mustache, ` +
           `preceeded by whitespace or a '=' character, and ` +
-          `followed by whitespace or a '>' character (on line ${line})`
+          `followed by whitespace, a '>' character or a '/>' (on line ${line})`
         );
       }
     }

--- a/packages/htmlbars-syntax/tests/parser-node-test.js
+++ b/packages/htmlbars-syntax/tests/parser-node-test.js
@@ -144,6 +144,13 @@ test("Handlebars embedded in an attribute (unquoted)", function() {
   ]));
 });
 
+test("Handlebars embedded in an attribute of a self-closing tag (unqouted)", function() {
+  var t = '<input value={{foo}}/>';
+  astEqual(t, b.program([
+    b.element("input", [ b.attr("value", b.mustache(b.path('foo'))) ], [], []),
+  ]));
+});
+
 test("Handlebars embedded in an attribute (sexprs)", function() {
   var t = 'some <div class="{{foo (foo "abc")}}">content</div> done';
   astEqual(t, b.program([


### PR DESCRIPTION
As specified in emberjs/ember.js#12769,

```handlebars
<input type="text" value={{favoriteBand}} onblur={{action "bandDidChange"}}/>
```

is valid HTML but HTMLbars was raising the following exception:

    An unquoted attribute value must be a string or a mustache, preceeded by
    whitespace or a '=' character, and followed by whitespace or a '>'
    character (on line X)

This commit addresses the problem and rephrases the assertion message.