### PR TITLE
[BUGFIX] Fix text input cursor behavior

### DIFF
--- a/packages/morph-attr/lib/main.js
+++ b/packages/morph-attr/lib/main.js
@@ -9,8 +9,16 @@ function getProperty() {
 
 function updateProperty(value) {
   if (this._renderedInitially === true || !isAttrRemovalValue(value)) {
-    // do not render if initial value is undefined or null
-    this.domHelper.setPropertyStrict(this.element, this.attrName, value);
+    let element = this.element;
+    let attrName = this.attrName;
+
+    if (attrName === 'value' && element.tagName === 'INPUT' && element.value === value) {
+      // Do nothing. Attempts to avoid accidently changing the input cursor location.
+      // See https://github.com/tildeio/htmlbars/pull/447 for more details.
+    } else {
+      // do not render if initial value is undefined or null
+      this.domHelper.setPropertyStrict(element, attrName, value);
+    }
   }
 
   this._renderedInitially = true;

--- a/packages/morph-attr/tests/attr-morph-test.js
+++ b/packages/morph-attr/tests/attr-morph-test.js
@@ -2,6 +2,7 @@
 
 import DOMHelper from "../dom-helper";
 import SafeString from "htmlbars-util/safe-string";
+import AttrMorph from "morph-attr";
 
 var svgNamespace = "http://www.w3.org/2000/svg",
     xlinkNamespace = "http://www.w3.org/1999/xlink";
@@ -248,4 +249,28 @@ test("embed src as data uri is sanitized", function() {
   equal( element.getAttribute('src'),
         'unsafe:data:image/svg+xml;base64,PH',
         'attribute is escaped');
+});
+
+// Regression test for https://github.com/tildeio/htmlbars/pull/447.
+test("the value property of an input element is not set if the value hasn't changed", function() {
+  let calls = 0;
+
+  let domHelperStub = {
+    setPropertyStrict() {
+      calls++;
+    }
+  };
+
+  let input = document.createElement('input');
+  let morph = AttrMorph.create(input, 'value', domHelperStub);
+
+  equal(calls, 0);
+  morph.setContent('one');
+  equal(calls, 1);
+  morph.setContent('one');
+  equal(calls, 1);
+  morph.setContent('two');
+  equal(calls, 2);
+  morph.setContent('two');
+  equal(calls, 2);
 });


### PR DESCRIPTION
People are using bound `<input>`s. For the most part everything works great.

```hbs
<input type="checkbox"
       checked={{user.isCool}}
       oninput={{action 'saveCoolness' user}} >

<textarea value={{user.description}}
          oninput={{action 'saveDescription' user}} >
```

```js
  actions: {
    saveCoolness(user, event) {
      user.set('isCool', event.target.checked);
      Ember.run.throttle(user, 'save', 500);
    },

    saveDescription(user, event) {
      user.set('description', event.target.value);
      Ember.run.throttle(user, 'save', 500);
    }
  }
```

But not everything is rainbows and butterflies. Text inputs have an annoying
wart. Whenever you update their `value`, the cursor is moved to the end of the
input. This becomes a problem when you are trying to edit text in the middle of
a text input. Curiously, this issue doesn't affect `<textarea>` (confirmed on
Firefox/Chrome/Safari).

Here's an [ember-twiddle](https://ember-twiddle.com/78a85b61f93b9ab17bde) that show cases the
current state of affairs.

## Why does this happen?

A little background first. When you edit a text input through the browser GUI the `oninput`
event is triggered. When you change the input element's `value` property, the `oninput`
event is _not_ fired, but the cursor is set to the end of the text field.

Now let's say you write

```hbs
<input value={{user.name}} oninput={{action 'updateName'}}>
```

and

```js
actions: {
  updateName(event) {
    this.set('user.name', event.target.value);
  }
}
```

If you edit the text input the browser will internally update the `value` property on the
input element and then fire the `oninput` event. Our handler mutates the value of `user.name`.
This triggers the `value={{user.name}}` binding to update, or in other words calls

```
input.value = user.name
```

## Proposed fix

In order to fix this we can avoid setting .value when we don't need to. This will skirt the issue
of resetting the cursor when `value` is mutated. Specifically, we add a guard to `PropertyAttrMorph`
so that we avoid calling `input.value = newValue` if the follow conditions are met:

  - `this.attrName === 'value'`
  - `this.element.tagName === 'INPUT'`
  - `this.element.value == newValue`


Here is an [ember-twiddle](https://ember-twiddle.com/61d13202dda26cbba195) with the patch applied.
Note how editing the Name text input works correctly now. Even dead keys work just fine! (Try
entering `Option-e + e` in the text input. It should generate a "é" character.)

## Trade-offs

Making this change has a small trade off. It alters DOM semantics so that, when the conditions
above are met, we treat the mutation as a no-op rather than a set-the-value-to-what-it-already-was.
We believe that this is a very small price to pay for a massive improvement in developer ergonomics.
