### PR TITLE
Handle null/undefined url in nodeProtocolForURL

### DIFF
--- a/packages/dom-helper/lib/main.js
+++ b/packages/dom-helper/lib/main.js
@@ -616,7 +616,10 @@ function browserProtocolForURL(url) {
 }
 
 function nodeProtocolForURL(url) {
-  var protocol = nodeURL.parse(url).protocol;
+  var protocol = null;
+  if (typeof url === 'string') {
+    protocol = nodeURL.parse(url).protocol;
+  }
   return (protocol === null) ? ':' : protocol;
 }
 


### PR DESCRIPTION
The node version of protocolForURL was throwing an exception if the url is undefined [here](https://github.com/tildeio/htmlbars/blob/master/packages/dom-helper/lib/main.js#L619).  This is invoked in [sanitizeAttributeValue](https://github.com/tildeio/htmlbars/blob/master/packages/morph-attr/lib/sanitize-attribute-value.js#L47).  This was calling issues for bound attributes with no value in FastBoot environments.

This PR returns a sensible default (`:`) from `nodeProtocolForURL` when the `url` argument is a non-string.

I'm not sure how to test this though.  I'd like to get a test in place if possible before merging.

/cc @tomdale 