### PR TITLE
Properly handle trailing whitespace controls.

### DIFF
--- a/packages/htmlbars-syntax/lib/parser/handlebars-node-visitors.js
+++ b/packages/htmlbars-syntax/lib/parser/handlebars-node-visitors.js
@@ -98,18 +98,11 @@ export default {
         appendChild(this.currentElement(), mustache);
     }
 
-
     return mustache;
   },
 
   ContentStatement: function(content) {
-    var changeLines = 0;
-    if (content.rightStripped) {
-      changeLines = leadingNewlineDifference(content.original, content.value);
-    }
-
-    this.tokenizer.line = content.loc.start.line + changeLines;
-    this.tokenizer.column = changeLines ? 0 : content.loc.start.column;
+    updateTokenizerLocation(this.tokenizer, content);
 
     this.tokenizer.tokenizePart(content.value);
     this.tokenizer.flushData();
@@ -150,19 +143,45 @@ export default {
   NullLiteral: function() {}
 };
 
-function leadingNewlineDifference(original, value) {
+function calculateRightStrippedOffsets(original, value) {
   if (value === '') {
     // if it is empty, just return the count of newlines
     // in original
-    return original.split("\n").length - 1;
+    return {
+      lines: original.split("\n").length - 1,
+      columns: 0
+    };
   }
 
   // otherwise, return the number of newlines prior to
   // `value`
   var difference = original.split(value)[0];
   var lines = difference.split(/\n/);
+  var lineCount = lines.length - 1;
 
-  return lines.length - 1;
+  return {
+    lines: lineCount,
+    columns: lines[lineCount].length
+  };
+}
+
+function updateTokenizerLocation(tokenizer, content) {
+  var line = content.loc.start.line;
+  var column = content.loc.start.column;
+
+  if (content.rightStripped) {
+    var offsets = calculateRightStrippedOffsets(content.original, content.value);
+
+    line = line + offsets.lines;
+    if (offsets.lines) {
+      column = offsets.columns;
+    } else {
+      column = column + offsets.columns;
+    }
+  }
+
+  tokenizer.line = line;
+  tokenizer.column = column;
 }
 
 function acceptCommonNodes(compiler, node) {

--- a/packages/htmlbars-syntax/tests/loc-node-test.js
+++ b/packages/htmlbars-syntax/tests/loc-node-test.js
@@ -253,3 +253,33 @@ test("char references", function() {
   locEqual(p, 2, 17, 3, 31);
   locEqual(text2, 2, 20, 3, 27);
 });
+
+test("whitespace control - trailing", function() {
+  var ast = parse(`
+  {{#if foo~}}
+    <div></div>
+  {{else~}}
+    {{bar}}
+  {{/if}}`);
+
+  let [,ifBlock] = ast.body;
+  let [div] = ifBlock.program.body;
+
+  locEqual(ifBlock, 2, 2, 6, 9, 'if block');
+  locEqual(div, 3, 4, 3, 15, 'div inside truthy if block');
+});
+
+test("whitespace control - leading", function() {
+  var ast = parse(`
+  {{~#if foo}}
+    <div></div>
+  {{~else}}
+    {{bar}}
+  {{~/if}}`);
+
+  let [ifBlock] = ast.body;
+  let [,div] = ifBlock.program.body;
+
+  locEqual(ifBlock, 2, 2, 6, 10, 'if block');
+  locEqual(div, 3, 4, 3, 15, 'div inside truthy if block');
+});


### PR DESCRIPTION
Previously, we were only handling the Handlebars default "eating" of a newline after a block statement but did not properly handle `~}}` at the end of a block statement.

This updates to also calculate the column offsets (and adds tests).

Given the following:

```hbs
{{#if foo~}}
  <div></div>
{{/if}}
```

Before these changes, the `<div>` would have a starting column of `0`.

After these changes, the `<div>` has the correct starting column of `2`.

---

Related to https://github.com/rwjblue/ember-template-lint/issues/34.