### PR TITLE
Add tests for unquoted attribute location info.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "htmlbars",
   "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#v0.2.3"
+    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#v0.2.4"
   },
   "devDependencies": {
     "loader": "stefanpenner/loader.js#7f79173fd5c61dc256af9aa01c56d50ebfec10fe",

--- a/packages/htmlbars-syntax/tests/loc-node-test.js
+++ b/packages/htmlbars-syntax/tests/loc-node-test.js
@@ -224,17 +224,19 @@ test("element attribute", function() {
   let ast = parse(`
     <div data-foo="blah"
       data-derp="lolol"
-data-barf="herpy">
+data-barf="herpy"
+  data-qux=lolnoquotes>
       Hi, fivetanley!
     </div>
   `);
 
   let [,div] = ast.body;
-  let [dataFoo,dataDerp,dataBarf] = div.attributes;
+  let [dataFoo,dataDerp,dataBarf, dataQux] = div.attributes;
 
   locEqual(dataFoo, 2, 9, 2, 24);
   locEqual(dataDerp, 3, 6, 3, 23);
   locEqual(dataBarf, 4, 0, 4, 17);
+  locEqual(dataQux, 5, 2, 5, 22);
 });
 
 test("char references", function() {


### PR DESCRIPTION
This requires https://github.com/tildeio/simple-html-tokenizer/pull/31 (published in simple-html-tokenizer@0.2.4) to pass.