### PR TITLE
Handle loc tracking locally.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "htmlbars",
   "dependencies": {
-    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#v0.2.4"
+    "simple-html-tokenizer": "tildeio/simple-html-tokenizer#v0.2.5"
   },
   "devDependencies": {
     "loader": "stefanpenner/loader.js#7f79173fd5c61dc256af9aa01c56d50ebfec10fe",

--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -154,7 +154,7 @@ export default {
       isQuoted: false,
       isDynamic: false,
       // beginAttribute isn't called until after the first char is consumed
-      start: b.pos(this.tokenizer.line, this.tokenizer.column - 1)
+      start: b.pos(this.tokenizer.line, this.tokenizer.column)
     };
   },
 

--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -13,7 +13,7 @@ export default {
     this.currentNode = b.comment("");
     this.currentNode.loc = {
       source: null,
-      start: b.pos(this.tokenizer.tagLine, this.tokenizer.tagColumn),
+      start: b.pos(this.tagOpenLine, this.tagOpenColumn),
       end: null
     };
   },
@@ -51,6 +51,11 @@ export default {
 
   // Tags - basic
 
+  tagOpen: function() {
+    this.tagOpenLine = this.tokenizer.line;
+    this.tagOpenColumn = this.tokenizer.column;
+  },
+
   beginStartTag: function() {
     this.currentNode = {
       type: 'StartTag',
@@ -74,10 +79,10 @@ export default {
   },
 
   finishTag: function() {
-    let { tagLine, tagColumn, line, column } = this.tokenizer;
+    let { line, column } = this.tokenizer;
 
     let tag = this.currentNode;
-    tag.loc = b.loc(tagLine, tagColumn, line, column);
+    tag.loc = b.loc(this.tagOpenLine, this.tagOpenColumn, line, column);
 
     if (tag.type === 'StartTag') {
       this.finishStartTag();
@@ -95,7 +100,7 @@ export default {
 
     validateStartTag(this.currentNode, this.tokenizer);
 
-    let loc = b.loc(this.tokenizer.tagLine, this.tokenizer.tagColumn);
+    let loc = b.loc(this.tagOpenLine, this.tagOpenColumn);
     let element = b.element(name, attributes, modifiers, [], loc);
     this.elementStack.push(element);
   },

--- a/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
+++ b/packages/htmlbars-syntax/lib/parser/tokenizer-event-handlers.js
@@ -154,7 +154,9 @@ export default {
       isQuoted: false,
       isDynamic: false,
       // beginAttribute isn't called until after the first char is consumed
-      start: b.pos(this.tokenizer.line, this.tokenizer.column)
+      start: b.pos(this.tokenizer.line, this.tokenizer.column),
+      valueStartLine: null,
+      valueStartColumn: null
     };
   },
 
@@ -164,6 +166,8 @@ export default {
 
   beginAttributeValue: function(isQuoted) {
     this.currentAttribute.isQuoted = isQuoted;
+    this.currentAttribute.valueStartLine = this.tokenizer.line;
+    this.currentAttribute.valueStartColumn = this.tokenizer.column;
   },
 
   appendToAttributeValue: function(char) {
@@ -177,8 +181,9 @@ export default {
   },
 
   finishAttributeValue: function() {
-    let { name, parts, isQuoted, isDynamic } = this.currentAttribute;
+    let { name, parts, isQuoted, isDynamic, valueStartLine, valueStartColumn} = this.currentAttribute;
     let value = assembleAttributeValue(parts, isQuoted, isDynamic, this.tokenizer.line);
+    value.loc = b.loc(valueStartLine, valueStartColumn, this.tokenizer.line, this.tokenizer.column);
 
     let loc = b.loc(
       this.currentAttribute.start.line, this.currentAttribute.start.column,

--- a/packages/htmlbars-syntax/tests/loc-node-test.js
+++ b/packages/htmlbars-syntax/tests/loc-node-test.js
@@ -225,18 +225,25 @@ test("element attribute", function() {
     <div data-foo="blah"
       data-derp="lolol"
 data-barf="herpy"
-  data-qux=lolnoquotes>
+  data-qux=lolnoquotes
+    data-hurky="some {{thing}} here">
       Hi, fivetanley!
     </div>
   `);
 
   let [,div] = ast.body;
-  let [dataFoo,dataDerp,dataBarf, dataQux] = div.attributes;
+  let [dataFoo,dataDerp,dataBarf, dataQux, dataHurky] = div.attributes;
 
   locEqual(dataFoo, 2, 9, 2, 24);
   locEqual(dataDerp, 3, 6, 3, 23);
   locEqual(dataBarf, 4, 0, 4, 17);
   locEqual(dataQux, 5, 2, 5, 22);
+
+  locEqual(dataFoo.value, 2, 18, 2, 24);
+  locEqual(dataDerp.value, 3, 16, 3, 23);
+  locEqual(dataBarf.value, 4, 10, 4, 17);
+  locEqual(dataQux.value, 5, 11, 5, 22);
+  locEqual(dataHurky.value, 6, 15, 6, 36);
 });
 
 test("char references", function() {


### PR DESCRIPTION
* Rely on simple-html-tokenizer calling `beginAttribute` correctly. Relies on changes in SHT to call `beginAttribute` with the proper `column` and `line` information.
* Use `tagOpen` hook to handle tag start loc tracking.
* Removes usage of `tagLine` and `tagColumn`.
* Track AttrNode value location information.