### PR TITLE
Force `download` attribute on `<a>` tag to be treated as an attribute

### DIFF
--- a/packages/dom-helper/lib/prop.js
+++ b/packages/dom-helper/lib/prop.js
@@ -39,6 +39,8 @@ export function normalizeProperty(element, slotName) {
 // * strange spec outlier
 var ATTR_OVERRIDES = {
 
+  A: { download: true },
+
   // phantomjs < 2.0 lets you set it as a prop but won't reflect it
   // back to the attribute. button.getAttribute('type') === null
   BUTTON: { type: true, form: true },

--- a/packages/dom-helper/tests/prop-test.js
+++ b/packages/dom-helper/tests/prop-test.js
@@ -3,9 +3,10 @@ import { normalizeProperty } from 'dom-helper/prop';
 QUnit.module('dom-helper prop');
 
 test('type.attr, for element props that for one reason or another need to be treated as attrs', function() {
-  expect(13);
+  expect(14);
 
   [
+    { tagName: 'A',        key: 'download' },
     { tagName: 'TEXTAREA', key: 'form' },
     { tagName: 'BUTTON',   key: 'type' },
     { tagName: 'INPUT',    key: 'type' },
@@ -13,7 +14,7 @@ test('type.attr, for element props that for one reason or another need to be tre
     { tagName: 'INPUT',    key: 'form' },
     { tagName: 'INPUT',    key: 'autocorrect' },
     { tagName: 'OPTION',   key: 'form' },
-    { tagName: 'INPUT',    key: 'form' },
+    { tagName: 'SELECT',   key: 'form' },
     { tagName: 'BUTTON',   key: 'form' },
     { tagName: 'LABEL',    key: 'form' },
     { tagName: 'FIELDSET', key: 'form' },

--- a/packages/morph-attr/tests/attr-morph-test.js
+++ b/packages/morph-attr/tests/attr-morph-test.js
@@ -132,6 +132,15 @@ test("can remove attribute with undefined", function(){
   equal(element.getAttribute('data-bop'), undefined, 'data-bop attribute is removed');
 });
 
+test("can remove `download` attribute with null", function(){
+  var element = domHelper.createElement('a');
+  var morph = domHelper.createAttrMorph(element, 'download');
+  morph.setContent('file.pdf');
+  equal(element.getAttribute('download'), 'file.pdf', 'download attribute is set');
+  morph.setContent(null);
+  equal(element.getAttribute('download'), undefined, 'download attribute is removed');
+});
+
 test("can remove ns attribute with undefined", function(){
   var element = domHelper.createElement('svg');
   domHelper.setAttribute(element, 'xlink:title', 'Great Title', xlinkNamespace);


### PR DESCRIPTION
Addresses [emberjs/ember.js #13537](https://github.com/emberjs/ember.js/issues/13537).

[`normalizeProperty`](https://github.com/tildeio/htmlbars/blob/master/packages/dom-helper/lib/prop.js#L11) interprets the `download` attribute as a property but, in my estimation, we want to treat it as an attribute, so I've added it to the [overrides object](https://github.com/tildeio/htmlbars/blob/master/packages/dom-helper/lib/prop.js#L40). If I am incorrect in this I can close this and update the original issue referenced above.
